### PR TITLE
Add Third Party Resources support

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -27,6 +27,8 @@ WATCH_OP_SUFFIX = "List"
 LIST_OP_PREFIX = "list"
 WATCH_QUERY_PARAM_NAME = "watch"
 
+TPR_SPEC_PATH = os.path.join(os.path.dirname(__file__), 'thirdpartypaths.json')
+
 _ops = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch']
 
 
@@ -95,7 +97,18 @@ def strip_tags_from_operation_id(operation, _):
     operation['operationId'] = operation_id
 
 
+def add_thirdparty_resource_paths(spec):
+    with open(TPR_SPEC_PATH, 'r') as third_party_spec_file:
+        third_party_spec = json.loads(third_party_spec_file.read())
+    for path in third_party_spec.keys():
+        if path not in spec['paths'].keys():
+            spec['paths'][path] = third_party_spec[path]
+    return spec
+
+
 def process_swagger(spec):
+    spec = add_thirdparty_resource_paths(spec)
+
     apply_func_to_spec_operations(spec, strip_tags_from_operation_id)
 
     operation_ids = {}

--- a/openapi/thirdpartypaths.json
+++ b/openapi/thirdpartypaths.json
@@ -1,0 +1,236 @@
+{
+  "/apis/{fqdn}/v1/{resource}": {
+    "get": {
+      "operationId": "listThirdPartyResource",
+      "summary": "Gets Resources",
+      "description": "Returns a list of Resources",
+      "tags": [
+        "third_party_resources"
+      ],
+      "parameters": [
+        {
+          "name": "watch",
+          "uniqueItems": true,
+          "type": "boolean",
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query"
+        },
+        {
+          "name": "fqdn",
+          "in": "path",
+          "required": true,
+          "description": "The Third party Resource fqdn",
+          "type": "string"
+        },
+        {
+          "name": "resource",
+          "in": "path",
+          "required": true,
+          "description": "The Resource type",
+          "type": "string"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of Resources",
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "/apis/{fqdn}/v1/namespaces/{namespace}/{resource}": {
+    "post": {
+      "operationId": "createThirdPartyResource",
+      "summary": "Create a Resource",
+      "description": "Creates a third party resource of the type specified",
+      "tags": [
+        "third_party_resources"
+      ],
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "required": true,
+          "description": "The Resource's namespace",
+          "type": "string"
+        },
+        {
+          "name": "fqdn",
+          "in": "path",
+          "required": true,
+          "description": "The Third party Resource fqdn",
+          "type": "string"
+        },
+        {
+          "name": "resource",
+          "in": "path",
+          "required": true,
+          "description": "The Resource type",
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "The JSON schema of the Resource to create.",
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "responses": {
+        "201": {
+          "description": "A list of Resources",
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "/apis/{fqdn}/v1/namespaces/{namespace}/{resource}/{name}": {
+    "get": {
+      "operationId": "getThirdPartyResource",
+      "summary": "Gets a specific Resource",
+      "description": "Returns a specific Resource in a namespace",
+      "tags": [
+        "third_party_resources"
+      ],
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "required": true,
+          "description": "The Resource's namespace",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "The Resource's name",
+          "type": "string"
+        },
+        {
+          "name": "fqdn",
+          "in": "path",
+          "required": true,
+          "description": "The Third party Resource fqdn",
+          "type": "string"
+        },
+        {
+          "name": "resource",
+          "in": "path",
+          "required": true,
+          "description": "The Resource type",
+          "type": "string"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "A single Resource",
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "delete": {
+      "operationId": "deleteThirdPartyResource",
+      "summary": "Deletes a specific Resource",
+      "description": "Deletes the specified Resource in the specified namespace",
+      "tags": [
+        "third_party_resources"
+      ],
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/v1.DeleteOptions"
+          }
+        },
+        {
+          "name": "gracePeriodSeconds",
+          "uniqueItems": true,
+          "type": "integer",
+          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+          "in": "query"
+        },
+        {
+          "name": "orphanDependents",
+          "uniqueItems": true,
+          "type": "boolean",
+          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+          "in": "query"
+        },
+        {
+          "name": "propagationPolicy",
+          "uniqueItems": true,
+          "type": "string",
+          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
+          "in": "query"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "OK",
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "put": {
+      "operationId": "updateThirdPartyResource",
+      "summary": "Update a Resource",
+      "description": "Update the specified third party resource of the type specified",
+      "tags": [
+        "third_party_resources"
+      ],
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "required": true,
+          "description": "The Resource's namespace",
+          "type": "string"
+        },
+        {
+          "name": "fqdn",
+          "in": "path",
+          "required": true,
+          "description": "The Third party Resource fqdn",
+          "type": "string"
+        },
+        {
+          "name": "resource",
+          "in": "path",
+          "required": true,
+          "description": "The Resource type",
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "The JSON schema of the Resource to create.",
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "responses": {
+        "201": {
+          "description": "A list of Resources",
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We recently added TPR support to python client. We need to port this change to gen repo before starting to use `gen` in python client. This means other languages can now support TPR (to be tested at least for java).

@brendandburns