### PR TITLE
Fix cleanup directories of java generator

### DIFF
--- a/openapi/java.sh
+++ b/openapi/java.sh
@@ -47,4 +47,4 @@ popd > /dev/null
 source "${SCRIPT_ROOT}/client-generator.sh"
 source "${SETTING_FILE}"
 
-CLIENT_LANGUAGE=java; CLEANUP_DIRS=(docs src gradle); kubeclient::generator::generate_client "${OUTPUT_DIR}"
+CLIENT_LANGUAGE=java; CLEANUP_DIRS=(docs src/test src/main/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/models src/main/java/io/kubernetes/client/auth gradle); kubeclient::generator::generate_client "${OUTPUT_DIR}"


### PR DESCRIPTION
Java generator script was removing all src folder before generation while we've added ApiClient.java to exception list. I've added more specific cleanup directories here to prevent ApiClient.java's removal.

ref: https://github.com/kubernetes-client/java/issues/38