### PR TITLE
Python 3 compatibility, allow preprocess_spec.py to be imported, and add descriptions to make Swagger validate

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -106,6 +106,7 @@
       ],
       "responses": {
         "201": {
+	    "description": "Created",
           "schema": {
             "type": "object"
           }
@@ -230,6 +231,7 @@
       ],
       "responses": {
         "201": {
+	    "description": "Created",
           "schema": {
             "type": "object"
           }


### PR DESCRIPTION
This is straightforward patch to address #19.  It also makes three more changes to address my use-case:
1. Encloses `sys.exit(main))` in `if __name__ == '__main__'` to allow access through Python's import functionality as well as through a subprocess call.
2. Adds the `__future__` import for the print function and turns print statements into print functions.
3. Replaces `iteritems()` with `items()`.

The first two of these shouldn't change anything but allow the code to be imported and to run on Python 3.  The third has possible performance implications because on Python 2 `items()` creates a list rather than an iterator.  The standard way of working around this difference is to use [six](https://pythonhosted.org/six/), but if you don't want to bother with the complication, just tell me and I'll remove that change from the pull request.