### PR TITLE
Better support for IntOrString

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -256,9 +256,11 @@ def inline_primitive_models(spec):
     to_remove_models = []
     for k, v in spec['definitions'].items():
         if "properties" not in v:
-            print("Making primitive mode `%s` inline ..." % k)
+            if k == "intstr.IntOrString":
+                v["type"] = "object"
             if "type" not in v:
                 v["type"] = "object"
+            print("Making model `%s` inline as %s..." % (k, v["type"]))
             find_replace_ref_recursive(spec, "#/definitions/" + k, v)
             to_remove_models.append(k)
 


### PR DESCRIPTION
Generators would behave better if IntOrString is an object. e.g. python client won't touch the type of IntOrString fields and thus they can be `int` or `str`. This will also allow round-tripping objects and prevents bug like https://github.com/kubernetes-incubator/client-python/issues/359
 