### PR TITLE
add support for lang specific Dockerfile

### DIFF
--- a/openapi/Dockerfile.csharp
+++ b/openapi/Dockerfile.csharp
@@ -1,0 +1,16 @@
+FROM node
+
+RUN npm install -g autorest
+
+ARG SWAGGER_CODEGEN_COMMIT
+ARG GENERATION_XML_FILE
+ARG SWAGGER_CODEGEN_USER_ORG
+
+RUN apt-get update && apt-get -y install python-pip && pip install urllib3
+RUN apt-get install libunwind8
+
+COPY generate_client_in_container.csharp.sh /generate_client.sh
+COPY preprocess_spec.py /
+COPY custom_objects_spec.json /
+
+ENTRYPOINT ["/generate_client.sh"]

--- a/openapi/client-generator.sh
+++ b/openapi/client-generator.sh
@@ -52,10 +52,10 @@ kubeclient::generator::generate_client() {
 
     mkdir -p "${output_dir}"
 
-    local docker_file="Dockerfile"
+    local docker_file="${SCRIPT_ROOT}/Dockerfile"
 
-    if [ -e "Dockerfile.${CLIENT_LANGUAGE}" ];then
-        docker_file="Dockerfile.${CLIENT_LANGUAGE}"
+    if [ -e "${SCRIPT_ROOT}/Dockerfile.${CLIENT_LANGUAGE}" ];then
+        docker_file="${SCRIPT_ROOT}/Dockerfile.${CLIENT_LANGUAGE}"
     fi
 
     echo "--- Building docker image..."

--- a/openapi/client-generator.sh
+++ b/openapi/client-generator.sh
@@ -52,8 +52,14 @@ kubeclient::generator::generate_client() {
 
     mkdir -p "${output_dir}"
 
+    local docker_file="Dockerfile"
+
+    if [ -e "Dockerfile.${CLIENT_LANGUAGE}" ];then
+        docker_file="Dockerfile.${CLIENT_LANGUAGE}"
+    fi
+
     echo "--- Building docker image..."
-    docker build "${SCRIPT_ROOT}" -t "kubernetes-${CLIENT_LANGUAGE}-client-gen:v1" \
+    docker build -f $docker_file "${SCRIPT_ROOT}" -t "kubernetes-${CLIENT_LANGUAGE}-client-gen:v1" \
         --build-arg SWAGGER_CODEGEN_COMMIT="${SWAGGER_CODEGEN_COMMIT}" \
         --build-arg GENERATION_XML_FILE="${CLIENT_LANGUAGE}.xml"
 

--- a/openapi/generate_client_in_container.csharp.sh
+++ b/openapi/generate_client_in_container.csharp.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to fetch latest swagger spec.
+# Puts the updated spec at api/swagger-spec/
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Generates client.
+# Required env vars:
+#   CLEANUP_DIRS: List of directories (string separated by space) to cleanup before generation for this language
+#   KUBERNETES_BRANCH: Kubernetes branch name to get the swagger spec from
+#   CLIENT_VERSION: Client version. Will be used in the comment sections of the generated code
+#   PACKAGE_NAME: Name of the client package.
+# Input vars:
+#   $1: output directory
+: "${CLEANUP_DIRS?Must set CLEANUP_DIRS env var}"
+: "${KUBERNETES_BRANCH?Must set KUBERNETES_BRANCH env var}"
+: "${CLIENT_VERSION?Must set CLIENT_VERSION env var}"
+: "${PACKAGE_NAME?Must set PACKAGE_NAME env var}"
+
+output_dir=$1
+pushd "${output_dir}" > /dev/null
+output_dir=`pwd`
+popd > /dev/null
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+pushd "${SCRIPT_ROOT}" > /dev/null
+SCRIPT_ROOT=`pwd`
+popd > /dev/null
+
+
+mkdir -p "${output_dir}"
+
+echo "--- Downloading and pre-processing OpenAPI spec"
+python "${SCRIPT_ROOT}/preprocess_spec.py" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json"
+
+echo "--- Cleaning up previously generated folders"
+for i in ${CLEANUP_DIRS}; do
+    echo "--- Cleaning up ${output_dir}/${i}"
+    rm -rf "${output_dir}/${i}"
+done
+
+echo "--- Generating client ..."
+# TODO new wayautorest --input-file "${output_dir}/swagger.json" --namespace "${PACKAGE_NAME}" --output-folder "${output_dir}" --add-credentials
+autorest -Input "${output_dir}/swagger.json" -CodeGenerator CSharp -Namespace "${PACKAGE_NAME}" -PackageVersion "${CLIENT_VERSION}"  -OutputDirectory "${output_dir}" -AddCredentials true
+
+mkdir -p "${output_dir}/.autorest-codegen"
+autorest --info --json > "${output_dir}/.autorest-codegen/autorest-info.json"
+
+echo "---Done."


### PR DESCRIPTION
`csharp` does not use swagger to generate its client code,
as a result, `csharp.sh` is not working due to autorest is not included in the docker image.
