### PR TITLE
Add support for IntOrString in Java

### DIFF
--- a/openapi/client-generator.sh
+++ b/openapi/client-generator.sh
@@ -66,6 +66,7 @@ kubeclient::generator::generate_client() {
         -e CLEANUP_DIRS="${CLEANUP_DIRS_STRING}" \
         -e KUBERNETES_BRANCH="${KUBERNETES_BRANCH}" \
         -e CLIENT_VERSION="${CLIENT_VERSION}" \
+        -e CLIENT_LANGUAGE="${CLIENT_LANGUAGE}" \
         -e PACKAGE_NAME="${PACKAGE_NAME}" \
         -e SWAGGER_CODEGEN_COMMIT="${SWAGGER_CODEGEN_COMMIT}" \
         -v "${output_dir}:/output_dir" \

--- a/openapi/generate_client_in_container.sh
+++ b/openapi/generate_client_in_container.sh
@@ -33,6 +33,7 @@ set -o pipefail
 : "${CLEANUP_DIRS?Must set CLEANUP_DIRS env var}"
 : "${KUBERNETES_BRANCH?Must set KUBERNETES_BRANCH env var}"
 : "${CLIENT_VERSION?Must set CLIENT_VERSION env var}"
+: "${CLIENT_LANGUAGE?Must set CLIENT_LANGUAGE env var}"
 : "${PACKAGE_NAME?Must set PACKAGE_NAME env var}"
 : "${SWAGGER_CODEGEN_COMMIT?Must set SWAGGER_CODEGEN_COMMIT env var}"
 
@@ -78,7 +79,7 @@ popd
 mkdir -p "${output_dir}"
 
 echo "--- Downloading and pre-processing OpenAPI spec"
-python "${SCRIPT_ROOT}/preprocess_spec.py" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json"
+python "${SCRIPT_ROOT}/preprocess_spec.py" "${CLIENT_LANGUAGE}" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json"
 
 echo "--- Cleaning up previously generated folders"
 for i in ${CLEANUP_DIRS}; do

--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -45,6 +45,8 @@
                 <dateLibrary>joda</dateLibrary>
                 <useRxJava>false</useRxJava>
                 <library>okhttp-gson</library>
+                <type-mappings>intstr.IntOrString=IntOrString</type-mappings>
+                <import-mappings>IntOrString=io.kubernetes.client.custom.IntOrString</import-mappings>
               </configOptions>
               <output>${generator.output.path}</output>
             </configuration>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -260,15 +260,16 @@ def find_replace_ref_recursive(root, ref_name, replace_map):
 def inline_primitive_models(spec, excluded_primitives):
     to_remove_models = []
     for k, v in spec['definitions'].items():
-        if k not in excluded_primitives:
-            if "properties" not in v:
-                if k == "intstr.IntOrString":
-                    v["type"] = "object"
-                if "type" not in v:
-                    v["type"] = "object"
-                print("Making model `%s` inline as %s..." % (k, v["type"]))
-                find_replace_ref_recursive(spec, "#/definitions/" + k, v)
-                to_remove_models.append(k)
+        if k in excluded_primitives:
+            continue
+        if "properties" not in v:
+            if k == "intstr.IntOrString":
+                v["type"] = "object"
+            if "type" not in v:
+                v["type"] = "object"
+            print("Making model `%s` inline as %s..." % (k, v["type"]))
+            find_replace_ref_recursive(spec, "#/definitions/" + k, v)
+            to_remove_models.append(k)
 
     for k in to_remove_models:
         del spec['definitions'][k]

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -282,7 +282,7 @@ def write_json(filename, object):
 
 def main():
     if len(sys.argv) != 4:
-        print("Usage:\n\n\tpython preprocess_spec.py client_language kuberneres_branch " \
+        print("Usage:\n\n\tpython preprocess_spec.py client_language kubernetes_branch " \
               "output_spec_path")
         return 1
     client_language = sys.argv[1]

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -276,8 +276,7 @@ def inline_primitive_models(spec, excluded_primitives):
 
 def write_json(filename, object):
     with open(filename, 'w') as out:
-        json.dump(object, out, sort_keys=False, indent=2,
-                  separators=(',', ': '), ensure_ascii=True)
+        json.dump(object, out, sort_keys=False, indent=2, separators=(',', ': '), ensure_ascii=True)
 
 
 


### PR DESCRIPTION
Allows certain languages to opt out of preprocessing away primitive types. This is done in order to allow the spec to be passed to Java containing the `intstr.IntOrString` type. This allows us to then rebind the type mapping for `intstr.IntOrString` to a custom class (see [PR in `java` client](https://github.com/kubernetes-client/java/pull/108)).