### PR TITLE
Fix crashes on Python 2.7+ and when an operation is missing the "tags" key

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -96,10 +96,10 @@ def remove_watch_operations(op, parent, operation_ids):
 
 def strip_tags_from_operation_id(operation, _):
     operation_id = operation['operationId']
-    for t in operation['tags']:
-        operation_id = operation_id.replace(_to_camel_case(t), '')
-    operation['operationId'] = operation_id
-
+    if 'tags' in operation:
+        for t in operation['tags']:
+            operation_id = operation_id.replace(_to_camel_case(t), '')
+        operation['operationId'] = operation_id
 
 def add_custom_objects_spec(spec):
     with open(CUSTOM_OBJECTS_SPEC_PATH, 'r') as custom_objects_spec_file:
@@ -123,7 +123,7 @@ def process_swagger(spec, client_language):
         apply_func_to_spec_operations(
             spec, remove_watch_operations, operation_ids)
     except PreprocessingException as e:
-        print(e.message)
+        print(e)
 
     remove_model_prefixes(spec)
 


### PR DESCRIPTION
This is a fix for two issues that I found while running the version of this script found in the [Openshift client](https://github.com/openshift/openshift-restclient-python).

1. When a PreprocessingException is caught and this line is executed, https://github.com/kubernetes-client/gen/blob/master/openapi/preprocess_spec.py#L126, on Python 2.7 and 3.x it will raise an AttributeError because the `.message` attribute on BaseException was a deprecated feature only available in 2.6: https://sayspy.blogspot.ie/2007/05/baseexceptionmessage-is-now-deprecated.html.

2. Some operations don't have the "tags" key on OpenShift.  As an example:

```
operation = {'description': 'create a Template', 'consumes': ['*/*'], 'produces': ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'], 'schemes': ['https'], 'operationId': 'createNamespacedProcessedTemplateV1', 'parameters': [{'name': 'body', 'in': 'body', 'required': True, 'schema': {'$ref': '#/definitions/com.github.openshift.origin.pkg.template.apis.template.v1.Template'}}], 'responses': {'200': {'description': 'OK', 'schema': {'$ref': '#/definitions/com.github.openshift.origin.pkg.template.apis.template.v1.Template'}}, '401': {'description': 'Unauthorized'}}}
```

In OpenAPI v.2.0, while "tags" is a fixed field for operations, it isn't marked as required so you still have valid OpenAPI if you leave it out, and `swagger-codegen validate` does pass on the OpenShift spec.  If you want me to print out the error or some thing else, please tell me.