### PR TITLE
Disable pre-processing for resource.Quantity

### DIFF
--- a/openapi/java.sh
+++ b/openapi/java.sh
@@ -49,5 +49,5 @@ source "${SETTING_FILE}"
 
 SWAGGER_CODEGEN_COMMIT=5d263e1c9cdd395d93adf061c63d5ef58a8e9ec5; \
 CLIENT_LANGUAGE=java; \
-CLEANUP_DIRS=(docs src/test src/main/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/models src/main/java/io/kubernetes/client/auth gradle); \
+CLEANUP_DIRS=(docs src/test/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/models src/main/java/io/kubernetes/client/auth gradle); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"

--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -45,8 +45,8 @@
                 <dateLibrary>joda</dateLibrary>
                 <useRxJava>false</useRxJava>
                 <library>okhttp-gson</library>
-                <type-mappings>intstr.IntOrString=IntOrString</type-mappings>
-                <import-mappings>IntOrString=io.kubernetes.client.custom.IntOrString</import-mappings>
+                <type-mappings>intstr.IntOrString=IntOrString,resource.Quantity=Quantity</type-mappings>
+                <import-mappings>IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity</import-mappings>
               </configOptions>
               <output>${generator.output.path}</output>
             </configuration>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -133,7 +133,7 @@ def process_swagger(spec, client_language):
 
 def preserved_primitives_for_language(client_language):
     if client_language == "java":
-        return ["intstr.IntOrString"]
+        return ["intstr.IntOrString", "resource.Quantity"]
     else:
         return []
 


### PR DESCRIPTION
Adds support for `Quantity` objects by not converting them to strings. Requires merging [#129 in the Java client](https://github.com/kubernetes-client/java/pull/129).