### PR TITLE
Add PATCH to CustomObjectsApi

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -106,7 +106,7 @@
       ],
       "responses": {
         "201": {
-	    "description": "Created",
+          "description": "Created",
           "schema": {
             "type": "object"
           }
@@ -231,7 +231,7 @@
       ],
       "responses": {
         "201": {
-	    "description": "Created",
+          "description": "Created",
           "schema": {
             "type": "object"
           }
@@ -344,6 +344,44 @@
           "type": "string",
           "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
           "in": "query"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "OK",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "401": {
+          "description": "Unauthorized"
+        }
+      }
+    },
+    "patch": {
+      "operationId": "patchClusterCustomObject",
+      "description": "patch the specified cluster scoped custom object",
+      "consumes": [
+        "application/merge-patch+json"
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "schemes": [
+        "https"
+      ],
+      "tags": [
+        "custom_objects"
+      ],
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "The JSON schema of the Resource to patch.",
+          "schema": {
+            "type": "object"
+          }
         }
       ],
       "responses": {
@@ -506,6 +544,44 @@
           "type": "string",
           "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
           "in": "query"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "OK",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "401": {
+          "description": "Unauthorized"
+        }
+      }
+    },
+    "patch": {
+      "operationId": "patchNamespacedCustomObject",
+      "description": "patch the specified namespace scoped custom object",
+      "consumes": [
+        "application/merge-patch+json"
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "schemes": [
+        "https"
+      ],
+      "tags": [
+        "custom_objects"
+      ],
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "required": true,
+          "description": "The JSON schema of the Resource to patch.",
+          "schema": {
+            "type": "object"
+          }
         }
       ],
       "responses": {


### PR DESCRIPTION
Currently the swagger schema for CustomObjectsApi does not support
PATCHing CustomObjects; only replacing. Both TPR and CRD support update
in their respective schemas.

This change adds the swagger schema to PATCH CustomObjects.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>