### PR TITLE
Add go generator

### DIFF
--- a/openapi/go.sh
+++ b/openapi/go.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARGC=$#
+
+if [ $# -ne 2 ]; then
+    echo "Usage:"
+    echo "    go.sh OUTPUT_DIR SETTING_FILE_PATH"
+    echo "    Setting file should define KUBERNETES_BRANCH, CLIENT_VERSION, and PACKAGE_NAME"
+    exit 1
+fi
+
+
+OUTPUT_DIR=$1
+SETTING_FILE=$2
+mkdir -p "${OUTPUT_DIR}"
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+pushd "${SCRIPT_ROOT}" > /dev/null
+SCRIPT_ROOT=`pwd`
+popd > /dev/null
+
+pushd "${OUTPUT_DIR}" > /dev/null
+OUTPUT_DIR=`pwd`
+popd > /dev/null
+
+source "${SCRIPT_ROOT}/client-generator.sh"
+source "${SETTING_FILE}"
+
+SWAGGER_CODEGEN_COMMIT=v2.3.0; \
+CLIENT_LANGUAGE=go; \
+CLEANUP_DIRS=(pkg); \
+kubeclient::generator::generate_client "${OUTPUT_DIR}"
+
+echo "---Done."

--- a/openapi/go.xml
+++ b/openapi/go.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.kubernetes</groupId>
+    <artifactId>client-go</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>client-go</name>
+    <url>http://kubernetes.io</url>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-codegen-maven-plugin</artifactId>
+                <version>${swagger-codegen-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${generator.spec.path}</inputSpec>
+                            <language>go</language>
+                            <gitUserId>kubernetes-client</gitUserId>
+                            <gitRepoId>go</gitRepoId>
+                            <configOptions>
+                                <packageName>${generator.package.name}</packageName>
+                                <packageVersion>${generator.client.version}</packageVersion>
+                            </configOptions>
+                            <output>${generator.output.path}</output>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <!-- dependencies are needed for the client being generated -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-annotations-version}</version>
+        </dependency>
+    </dependencies>
+    <properties>
+        <swagger-annotations-version>1.5.0</swagger-annotations-version>
+        <maven-plugin-version>1.0.0</maven-plugin-version>
+
+        <!-- Default values for the generator parameters. -->
+        <generator.output.path>.</generator.output.path>
+        <generator.spec.path>swagger.json</generator.spec.path>
+        <generator.package.name>swagger_client</generator.package.name>
+        <generator.client.version>unversioned</generator.client.version>
+    </properties>
+</project>


### PR DESCRIPTION
Adding scripts to generate client for go language.

Note: Go language is not supported yet. The generator is supported as it uses swagger-codegen but the generated client and its repo is not supported yet.

cc @roycaihw