### PR TITLE
feat: support for 3.7 (workaround)

### DIFF
--- a/openapi/python-asyncio.sh
+++ b/openapi/python-asyncio.sh
@@ -62,6 +62,13 @@ find "${OUTPUT_DIR}/client" -type f -name \*.py ! -name '__init__.py' -exec sed 
 # + support application/strategic-merge-patch+json
 patch "${OUTPUT_DIR}/client/rest.py" "${SCRIPT_ROOT}/python-asyncio-rest.py.patch"
 
+# workaround https://github.com/swagger-api/swagger-codegen/pull/8401
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async=/async_req=/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async bool/async_req bool/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i "s/'async'/'async_req'/g" {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i "s/async parameter/async_req parameter/g" {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i "s/if not async/if not async_req/g" {} +
+
 # fix imports
 find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes_asyncio.client./g' {} +
 find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes_asyncio.client/g' {} +

--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -52,6 +52,14 @@ CLEANUP_DIRS=(client/apis client/models docs test); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"
 
 echo "--- Patching generated code..."
+
+# workaround https://github.com/swagger-api/swagger-codegen/pull/8401
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async=/async_req=/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async bool/async_req bool/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i "s/'async'/'async_req'/g" {} +
+sed -i "s/if not async/if not async_req/g" "${OUTPUT_DIR}/client/api_client.py"
+#
+
 find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i 's/\bclient/kubernetes.client/g' {} +
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/\bclient/kubernetes.client/g' {} +
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes.client-python/client-python/g' {} +


### PR DESCRIPTION
Python 3.7 treats `async` as a reserved keywords. Unfortunately this phrase is used by swagger-codegen to call function in the asynchronous way (in a thread pool). I've created a fix for swagger-codegen (use `async_req` instead of `async`): https://github.com/swagger-api/swagger-codegen/pull/8401. Because merge and upgrade may take some time so here I send simple workaround.

Please be aware that is breaking change. API calls will have different arguments (async_req).

Before:
```
thread = api.create_namespaced_deployment(namespace, my_dep, async=True)
```

After:
```
thread = api.create_namespaced_deployment(namespace, my_dep, async_req=True)
```

Related issue: https://github.com/kubernetes-client/python/issues/558