### PR TITLE
fix: python/aiohttp with verify_ssl=False

### DIFF
--- a/openapi/python-asyncio-rest.py.patch
+++ b/openapi/python-asyncio-rest.py.patch
@@ -1,6 +1,10 @@
 21a22,23
 > import asyncio
 > 
+67c69
+<             ssl_context=ssl_context,
+---
+>             ssl_context=ssl_context if configuration.verify_ssl else None,
 81a84,86
 >     def __del__(self):
 >         asyncio.ensure_future(self.pool_manager.close())

--- a/openapi/python-asyncio.sh
+++ b/openapi/python-asyncio.sh
@@ -71,6 +71,8 @@ if [ ${PACKAGE_NAME} == "client" ]; then
   # workaround https://github.com/swagger-api/swagger-codegen/pull/8204
   # + closing session
   # + support application/strategic-merge-patch+json
+  # workaround https://github.com/swagger-api/swagger-codegen/pull/8507
+  # + aiohttp without verify_ssl
   patch "${OUTPUT_DIR}/client/rest.py" "${SCRIPT_ROOT}/python-asyncio-rest.py.patch"
 
   # workaround https://github.com/swagger-api/swagger-codegen/pull/8401


### PR DESCRIPTION
The library aiohttp used by kubernetes_asyncio doesn't accept ssl_context when user doesn't want to verify ssl. This bug is already reported here: https://github.com/swagger-api/swagger-codegen/pull/8507

Thanks.