### PR TITLE
PR to remediate kubernetes-client/gen/openapi/python.sh - 'no such file or directory' error

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -54,10 +54,10 @@ kubeclient::generator::generate_client "${OUTPUT_DIR}"
 echo "--- Patching generated code..."
 
 # workaround https://github.com/swagger-api/swagger-codegen/pull/8401
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async=/async_req=/g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/async bool/async_req bool/g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i "s/'async'/'async_req'/g" {} +
-sed -i "s/if not async/if not async_req/g" "${OUTPUT_DIR}/client/api_client.py"
+find "${OUTPUT_DIR}/" -type f -name \*.py -exec sed -i 's/async=/async_req=/g' {} +
+find "${OUTPUT_DIR}/" -type f -name \*.py -exec sed -i 's/async bool/async_req bool/g' {} +
+find "${OUTPUT_DIR}/" -type f -name \*.py -exec sed -i "s/'async'/'async_req'/g" {} +
+find "${OUTPUT_DIR}/" -name api_client.py -exec sed -i "s/if not async/if not async_req/g" {} +
 #
 
 find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i 's/\bclient/kubernetes.client/g' {} +


### PR DESCRIPTION
…#83)
This PR fixes the issue referenced by the above link: 
This fix has been tested with update-client.sh
( https://github.com/kubernetes-client/python/blob/master/scripts/update-client.sh )
and also with the example run noted in the issue where this error was noted. 
Both tests were successful. 