### PR TITLE
fix: syntax of python-asyncio-rest.py.patch

### DIFF
--- a/openapi/python-asyncio-rest.py.patch
+++ b/openapi/python-asyncio-rest.py.patch
@@ -5,7 +5,7 @@
 >         if not configuration.verify_ssl:
 >             ssl_context.check_hostname = False
 >             ssl_context.verify_mode = ssl.CERT_NONE
->
+> 
 67,68c73
 <             ssl_context=ssl_context,
 <             verify_ssl=configuration.verify_ssl


### PR DESCRIPTION
oops,  I accidentally removed a space from the patch file and now it can't be applied. Patch reports an error:

```
patch: **** '>' expected at line 8 of patch
```