### PR TITLE
Add timeoutSeconds to CustomObjectsApi list/watch calls

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -62,6 +62,13 @@
           "in": "query"
         },
         {
+          "uniqueItems": true,
+          "type": "integer",
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "name": "timeoutSeconds",
+          "in": "query"
+        },
+        {
           "name": "watch",
           "uniqueItems": true,
           "type": "boolean",
@@ -186,6 +193,13 @@
           "name": "resourceVersion",
           "in": "query"
         },
+        {
+          "uniqueItems": true,
+          "type": "integer",
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "name": "timeoutSeconds",
+          "in": "query"
+        }
         {
           "name": "watch",
           "uniqueItems": true,

--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -199,7 +199,7 @@
           "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
           "name": "timeoutSeconds",
           "in": "query"
-        }
+        },
         {
           "name": "watch",
           "uniqueItems": true,


### PR DESCRIPTION
I noticed that the Python client is missing the `timeoutSeconds` param for listing custom objects -- this PR adds it to `custom_objects_spec.json`