### PR TITLE
feat: add x-codegen-request-body-name in preprocessing step

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -110,11 +110,17 @@ def add_custom_objects_spec(spec):
             spec['paths'][path] = custom_objects_spec[path]
     return spec
 
+def add_codegen_request_body(operation, _):
+    if 'parameters' in operation and len(operation['parameters']) > 0:
+        if operation['parameters'][0].get('in') == 'body':
+            operation['x-codegen-request-body-name'] = 'body'
 
 def process_swagger(spec, client_language):
     spec = add_custom_objects_spec(spec)
 
     apply_func_to_spec_operations(spec, strip_tags_from_operation_id)
+
+    apply_func_to_spec_operations(spec, add_codegen_request_body)
 
     operation_ids = {}
     apply_func_to_spec_operations(spec, lambda op, _: operator.setitem(
@@ -295,7 +301,7 @@ def main():
     )
     argparser.add_argument(
         'output_spec_path',
-        help='Path to otput spec file to'
+        help='Path to output spec file to'
     )
     argparser.add_argument(
         'username',


### PR DESCRIPTION
The openapi-generator uses the model name as the name for the request body parameter (more details [migration-from-swagger-codegen/body-parameter-name](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/migration-from-swagger-codegen.md#body-parameter-name)). It makes differences in generated clients, for instance: https://github.com/tomplus/kubernetes_asyncio/pull/58#discussion_r247268574 It can be fixed by adding an additional attribute to the spec, which is ignored by the swagger-codegen.

Ref: https://github.com/kubernetes-client/gen/issues/93