### PR TITLE
feat: switch python client to use openapi-generator

### DIFF
--- a/openapi/python.xml
+++ b/openapi/python.xml
@@ -8,9 +8,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>${swagger-codegen-version}</version>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -36,7 +36,7 @@
     <dependencies>
         <!-- dependencies are needed for the client being generated -->
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>org.openapitools</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>


### PR DESCRIPTION
The Python will be generated by openapi-generator. I also prepared this PR: https://github.com/kubernetes-client/python/pull/738 to show what changes will be introduced to the generated client. Unfortunately this client used very old version of swagger-codegen.

Ref: https://github.com/kubernetes-client/gen/issues/93

PTAL: @yliaog @roycaihw @mbohlool @brendandburns 