### PR TITLE
Set requestType and configType for haskell

### DIFF
--- a/openapi/haskell-http-client.xml
+++ b/openapi/haskell-http-client.xml
@@ -26,6 +26,8 @@
                                 <allowNonUniqueOperationIds>true</allowNonUniqueOperationIds>
                                 <cabalPackage>kubernetes-openapi</cabalPackage>
                                 <baseModule>Kubernetes.OpenAPI</baseModule>
+                                <requestType>KubernetesRequest</requestType>
+                                <configType>KubernetesClientConfig</configType>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/openapi/haskell.sh
+++ b/openapi/haskell.sh
@@ -59,11 +59,11 @@ CABAL_OVERRIDES=(homepage https://github.com/kubernetes-client/haskell
 
 patch_cabal_file() {
     while [[ $# -gt 1 ]]; do
-        sed -i 's|^\('$1':[[:space:]]*\).*|\1'"$2"'|' ${OUTPUT_DIR}/kubernetes.cabal
+        sed -i 's|^\('$1':[[:space:]]*\).*|\1'"$2"'|' ${OUTPUT_DIR}/*.cabal
         shift 2
     done
 }
 patch_cabal_file "${CABAL_OVERRIDES[@]}"
 
-sed -i '/^copyright:/d' ${OUTPUT_DIR}/kubernetes.cabal
+sed -i '/^copyright:/d' ${OUTPUT_DIR}/*.cabal
 echo "---Done."


### PR DESCRIPTION
Without setting these names explicitly, the default is `OpenAPIRequest` and `OpenAPIConfig`, derived from the base module name.

Also a minor change in haskell.sh to account for the fact that the .cabal file generated is no longer named kubernetes.cabal, but rather controlled by the cabalPackage option.