### PR TITLE
Fix missing proto APIs

### DIFF
--- a/proto/dependencies.sh
+++ b/proto/dependencies.sh
@@ -29,7 +29,7 @@ mkdir -p k8s.io/api/rbac/v1
 mkdir -p k8s.io/api/rbac/v1beta1
 mkdir -p k8s.io/api/networking/v1
 mkdir -p k8s.io/api/settings/v1alpha1
-mkdir -p k8s.io/api/admissionregistration/v1alpha1
+mkdir -p k8s.io/api/admissionregistration/v1beta1
 mkdir -p k8s.io/api/scheduling/v1alpha1
 mkdir -p k8s.io/api/storage/v1
 mkdir -p k8s.io/api/storage/v1beta1
@@ -46,6 +46,7 @@ mkdir -p k8s.io/api/policy/v1beta1
 mkdir -p k8s.io/api/core/v1
 mkdir -p k8s.io/api/autoscaling/v1
 mkdir -p k8s.io/api/autoscaling/v2beta1
+mkdir -p k8s.io/api/autoscaling/v2beta2
 mkdir -p k8s.io/api/extensions/v1beta1
 mkdir -p k8s.io/api/certificates/v1beta1
 mkdir -p k8s.io/api/imagepolicy/v1alpha1
@@ -76,7 +77,7 @@ curl -s ${base}/api/master/rbac/v1/generated.proto > k8s.io/api/rbac/v1/generate
 curl -s ${base}/api/master/rbac/v1beta1/generated.proto > k8s.io/api/rbac/v1beta1/generated.proto
 curl -s ${base}/api/master/networking/v1/generated.proto > k8s.io/api/networking/v1/generated.proto
 curl -s ${base}/api/master/settings/v1alpha1/generated.proto > k8s.io/api/settings/v1alpha1/generated.proto
-curl -s ${base}/api/master/admissionregistration/v1alpha1/generated.proto > k8s.io/api/admissionregistration/v1alpha1/generated.proto
+curl -s ${base}/api/master/admissionregistration/v1beta1/generated.proto > k8s.io/api/admissionregistration/v1beta1/generated.proto
 curl -s ${base}/api/master/scheduling/v1alpha1/generated.proto > k8s.io/api/scheduling/v1alpha1/generated.proto
 curl -s ${base}/api/master/storage/v1/generated.proto > k8s.io/api/storage/v1/generated.proto
 curl -s ${base}/api/master/storage/v1beta1/generated.proto > k8s.io/api/storage/v1beta1/generated.proto
@@ -93,6 +94,7 @@ curl -s ${base}/api/master/policy/v1beta1/generated.proto > k8s.io/api/policy/v1
 curl -s ${base}/api/master/core/v1/generated.proto > k8s.io/api/core/v1/generated.proto
 curl -s ${base}/api/master/autoscaling/v1/generated.proto > k8s.io/api/autoscaling/v1/generated.proto
 curl -s ${base}/api/master/autoscaling/v2beta1/generated.proto > k8s.io/api/autoscaling/v2beta1/generated.proto
+curl -s ${base}/api/master/autoscaling/v2beta2/generated.proto > k8s.io/api/autoscaling/v2beta2/generated.proto
 curl -s ${base}/api/master/extensions/v1beta1/generated.proto > k8s.io/api/extensions/v1beta1/generated.proto
 curl -s ${base}/api/master/certificates/v1beta1/generated.proto > k8s.io/api/certificates/v1beta1/generated.proto
 curl -s ${base}/api/master/imagepolicy/v1alpha1/generated.proto > k8s.io/api/imagepolicy/v1alpha1/generated.proto

--- a/proto/generate.sh
+++ b/proto/generate.sh
@@ -40,7 +40,7 @@ files="k8s.io/apimachinery/pkg/api/resource/generated.proto;Resource \
        k8s.io/api/rbac/v1beta1/generated.proto;V1beta1Rbac \
        k8s.io/api/networking/v1/generated.proto;V1Networking \
        k8s.io/api/settings/v1alpha1/generated.proto;V1alpha1Settings \
-       k8s.io/api/admissionregistration/v1alpha1/generated.proto;V1alpha1Admissionregistration \
+       k8s.io/api/admissionregistration/v1beta1/generated.proto;V1beta1Admissionregistration \
        k8s.io/api/scheduling/v1alpha1/generated.proto;V1alpha1Scheduling \
        k8s.io/api/storage/v1/generated.proto;V1Storage \
        k8s.io/api/storage/v1beta1/generated.proto;V1beta1Storage \
@@ -57,6 +57,7 @@ files="k8s.io/apimachinery/pkg/api/resource/generated.proto;Resource \
        k8s.io/api/core/v1/generated.proto;V1 \
        k8s.io/api/autoscaling/v1/generated.proto;V1Autoscaling \
        k8s.io/api/autoscaling/v2beta1/generated.proto;V2beta1Autoscaling \
+       k8s.io/api/autoscaling/v2beta2/generated.proto;V2beta2Autoscaling \
        k8s.io/api/extensions/v1beta1/generated.proto;V1beta1Extensions \
        k8s.io/api/certificates/v1beta1/generated.proto;V1beta1Certificates \
        k8s.io/api/imagepolicy/v1alpha1/generated.proto;V1alpha1Imagepolicy \


### PR DESCRIPTION

 * Adds missing Autoscaling v2beta2 API
 * Fixes AdmissionRegistration by updating to v1beta1 from v1alpha1 whose files were deleted in [this commit](https://github.com/kubernetes/api/commit/2c7a0b47a38d8a0afb44646d031c7178bee2c180)

 Fixes #99 