### PR TITLE
cleanup: avoid backup python api_client when patch

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -63,7 +63,7 @@ sed -i "s/if not async/if not async_req/g" "${OUTPUT_DIR}/${PACKAGE_NAME}/api_cl
 
 # workaround https://github.com/swagger-api/swagger-codegen/pull/8061 (thread pool only on demand)
 # TODO: Remove this when above merges
-patch "${OUTPUT_DIR}/${PACKAGE_NAME}/api_client.py" "${SCRIPT_ROOT}/python-api_client.py.patch"
+patch "${OUTPUT_DIR}/${PACKAGE_NAME}/api_client.py" "${SCRIPT_ROOT}/python-api_client.py.patch" --no-backup-if-mismatch
 
 find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i 's/\bclient/kubernetes.client/g' {} +
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/\bclient/kubernetes.client/g' {} +


### PR DESCRIPTION
[api_client.py](https://github.com/kubernetes-client/python/pull/748#issuecomment-461237698) got backed up during release. I think it's because the patch contains a [version number](https://github.com/kubernetes-client/gen/blob/95d8a2bda6cdb6b432a0cccbbbd0ffd0c25617fc/openapi/python-api_client.py.patch#L22) which changes every release, so the patch detects mismatch and does a backup for the original file
```
$ git diff kubernetes/client/api_client.py > tmpd
$ diff tmpd ../gen/openapi/python-api_client.py.patch
1,2d0
< diff --git a/kubernetes/client/api_client.py b/kubernetes/client/api_client.py
< index 0c58dc04..68f16300 100644
24c22
<          self.user_agent = 'Swagger-Codegen/9.0.0-snapshot/python'
---
>          self.user_agent = 'Swagger-Codegen/8.0.0-snapshot/python'
```

this PR prevents backup since we don't need to check-in the original file anyway

cc @tomplus 