### PR TITLE
Switch ruby client to use openapi-generator

### DIFF
--- a/openapi/ruby.sh
+++ b/openapi/ruby.sh
@@ -43,7 +43,7 @@ pushd "${OUTPUT_DIR}" > /dev/null
 OUTPUT_DIR=`pwd`
 popd > /dev/null
 
-source "${SCRIPT_ROOT}/swagger-codegen/client-generator.sh"
+source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
 CLIENT_LANGUAGE=ruby; \

--- a/openapi/ruby.xml
+++ b/openapi/ruby.xml
@@ -8,9 +8,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>${swagger-codegen-version}</version>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
- Related issue : https://github.com/kubernetes-client/gen/issues/93
- Similar PR on the python client : https://github.com/kubernetes-client/gen/pull/97

