### PR TITLE
[Ruby] Exclude test codes from code generation

### DIFF
--- a/openapi/ruby.sh
+++ b/openapi/ruby.sh
@@ -47,5 +47,5 @@ source "${SCRIPT_ROOT}/swagger-codegen/client-generator.sh"
 source "${SETTING_FILE}"
 
 CLIENT_LANGUAGE=ruby; \
-CLEANUP_DIRS=(docs lib spec); \
+CLEANUP_DIRS=(docs lib); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"

--- a/openapi/ruby.xml
+++ b/openapi/ruby.xml
@@ -21,6 +21,8 @@
                             <language>ruby</language>
                             <gitUserId>kubernetes-client</gitUserId>
                             <gitRepoId>ruby</gitRepoId>
+                            <apiTests>false</apiTests>
+                            <modelTests>false</modelTests>
                             <configOptions>
                                 <gemName>kubernetes</gemName>
                                 <moduleName>Kubernetes</moduleName>


### PR DESCRIPTION
Related issue on `kubernetes-client/ruby` : https://github.com/kubernetes-client/ruby/issues/29

This PR solves the two issues:

- [1] There are not only auto-generated codes but also "hand-written" test codes under [`spec`](https://github.com/kubernetes-client/ruby/tree/master/kubernetes/spec) folder.
  - e.g. [spec/config/incluster_config_spec.rb](https://github.com/kubernetes-client/ruby/blob/master/kubernetes/spec/config/incluster_config_spec.rb)
  - [Unintentionally, the hand-written codes are deleted on re-generation](https://github.com/kubernetes-client/ruby/issues/29#issue-411168819)
  - To avoid that, we need to exclude the `spec` folder from cleanup ( https://github.com/kubernetes-client/gen/commit/9f57a86ee188147fd8c693b694e630e1c9e1e952 )
- [2] The auto-generated test codes are just skelton
  - so it is unnecessary to generate. ( https://github.com/kubernetes-client/gen/commit/8fae10df2972e319d58acb83bf0588b0ec44d0c3 )

---

After this PR has been merged, I would file a PR to `kubernetes-client/ruby` which cleanup(removes) the auto-generated test codes under `spec` folder.
