### PR TITLE
add remove_models (specific to client languages) in process_swagger

### DIFF
--- a/openapi/haskell-http-client.xml
+++ b/openapi/haskell-http-client.xml
@@ -29,6 +29,9 @@
                                 <baseModule>Kubernetes.OpenAPI</baseModule>
                                 <requestType>KubernetesRequest</requestType>
                                 <configType>KubernetesClientConfig</configType>
+                                <type-mappings>intstr.IntOrString=IntOrString</type-mappings>
+                                <import-mappings>IntOrString=Kubernetes.OpenAPI.CustomTypes</import-mappings>
+                                <customTestInstanceModule>CustomInstances</customTestInstanceModule>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/openapi/haskell.sh
+++ b/openapi/haskell.sh
@@ -46,8 +46,8 @@ popd > /dev/null
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
-# Latest version as of Mar 11, 2019
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-aa7ea8bdcae35d7800dc0218bb31e84952f43c62}"; \
+# Latest version as of Mar 15, 2019
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-c9737cf97d5e31936639842d389118e980ee85a9}"; \
 CLIENT_LANGUAGE=haskell-http-client; \
 CLEANUP_DIRS=(lib tests); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -136,6 +136,8 @@ def process_swagger(spec, client_language):
 
     inline_primitive_models(spec, preserved_primitives_for_language(client_language))
 
+    remove_models(spec, removed_models_for_language(client_language))
+
     return spec
 
 def preserved_primitives_for_language(client_language):
@@ -143,6 +145,14 @@ def preserved_primitives_for_language(client_language):
         return ["intstr.IntOrString", "resource.Quantity"]
     elif client_language == "csharp":
         return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
+    elif client_language == "haskell-http-client":
+        return ["intstr.IntOrString"]
+    else:
+        return []
+
+def removed_models_for_language(client_language):
+    if client_language == "haskell-http-client":
+        return ["intstr.IntOrString"]
     else:
         return []
 
@@ -265,6 +275,11 @@ def find_replace_ref_recursive(root, ref_name, replace_map):
         for k, v in root.items():
             find_replace_ref_recursive(v, ref_name, replace_map)
 
+
+def remove_models(spec, to_remove_models):
+    for k in to_remove_models:
+        print("Removing model `%s " % k)
+        del spec['definitions'][k]
 
 def inline_primitive_models(spec, excluded_primitives):
     to_remove_models = []


### PR DESCRIPTION
This is needed because openapi-generator does not allow us to override
a model definition such as IntOrString, if it exists in the json.

Once the model is removed, it can be re-mapped with a type-mapping

This change should not affect any client language, other than haskell.