### PR TITLE
Chore: Migrate java clients from swagger-codegen to openapi-generator

### DIFF
--- a/openapi/java.sh
+++ b/openapi/java.sh
@@ -46,10 +46,10 @@ pushd "${OUTPUT_DIR}" > /dev/null
 OUTPUT_DIR=`pwd`
 popd > /dev/null
 
-source "${SCRIPT_ROOT}/swagger-codegen/client-generator.sh"
+source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
-SWAGGER_CODEGEN_COMMIT="${SWAGGER_CODEGEN_COMMIT:-5d263e1c9cdd395d93adf061c63d5ef58a8e9ec5}"; \
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.2.0}" \
 CLIENT_LANGUAGE=java; \
-CLEANUP_DIRS=(docs src/test/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/apis src/main/java/io/kubernetes/client/models src/main/java/io/kubernetes/client/auth gradle); \
+CLEANUP_DIRS=(docs src/test/java/io/kubernetes/openapi/apis src/main/java/io/kubernetes/openapi/apis src/main/java/io/kubernetes/openapi/models src/main/java/io/kubernetes/openapi/auth gradle); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"

--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -1,5 +1,5 @@
-<project 
-  xmlns="http://maven.apache.org/POM/4.0.0" 
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.kubernetes</groupId>
@@ -10,9 +10,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.swagger</groupId>
-        <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>${swagger-codegen-version}</version>
+        <groupId>org.openapitools</groupId>
+        <artifactId>openapi-generator-maven-plugin</artifactId>
+        <version>${openapi-generator-version}</version>
         <executions>
           <execution>
             <goals>
@@ -23,6 +23,7 @@
               <language>java</language>
               <gitUserId>kubernetes-client</gitUserId>
               <gitRepoId>client-java</gitRepoId>
+              <skipValidateSpec>true</skipValidateSpec>
               <configOptions>
                 <projectName>kubernetes-java-client</projectName>
                 <projectDescription>Java client for Kubernetes.</projectDescription>
@@ -37,7 +38,6 @@
                 <artifactId>client-java</artifactId>
                 <artifactVersion>1.0-SNAPSHOT</artifactVersion>
                 <sourceFolder>src/main/java</sourceFolder>
-                <localVariablePrefix></localVariablePrefix>
                 <serializableModel>false</serializableModel>
                 <bigDecimalAsString>false</bigDecimalAsString>
                 <fullJavaUtil>false</fullJavaUtil>
@@ -45,11 +45,10 @@
                 <dateLibrary>joda</dateLibrary>
                 <useRxJava>false</useRxJava>
                 <library>okhttp-gson</library>
-                <type-mappings>intstr.IntOrString=IntOrString,resource.Quantity=Quantity</type-mappings>
-                <import-mappings>
-                  IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity,V1Patch=io.kubernetes.client.custom.V1Patch
-                </import-mappings>
+                <useReflectionEqualsHashCode>true</useReflectionEqualsHashCode>
               </configOptions>
+              <typeMappings>int-or-string=IntOrString,quantity=Quantity</typeMappings>
+              <importMappings>IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity</importMappings>
               <output>${generator.output.path}</output>
             </configuration>
           </execution>
@@ -65,9 +64,9 @@
       <version>${swagger-annotations-version}</version>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-codegen-maven-plugin</artifactId>
-      <version>2.2.2</version>
+      <groupId>org.openapitools</groupId>
+      <artifactId>openapi-generator-maven-plugin</artifactId>
+      <version>${openapi-generator-version}</version>
     </dependency>
   </dependencies>
   <properties>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -136,6 +136,8 @@ def process_swagger(spec, client_language):
 
     inline_primitive_models(spec, preserved_primitives_for_language(client_language))
 
+    add_custom_formatting(spec, format_for_language(client_language))
+
     remove_models(spec, removed_models_for_language(client_language))
 
     return spec
@@ -149,6 +151,12 @@ def preserved_primitives_for_language(client_language):
         return ["intstr.IntOrString", "resource.Quantity"]
     else:
         return []
+
+def format_for_language(client_language):
+    if client_language == "java":
+        return {"resource.Quantity": "quantity"}
+    else:
+        return {}
 
 def removed_models_for_language(client_language):
     if client_language == "haskell-http-client":
@@ -297,6 +305,12 @@ def inline_primitive_models(spec, excluded_primitives):
 
     for k in to_remove_models:
         del spec['definitions'][k]
+
+def add_custom_formatting(spec, custom_formats):
+    for k, v in spec['definitions'].items():
+        if k not in custom_formats:
+            continue
+        v["format"] = custom_formats[k]
 
 def write_json(filename, object):
     with open(filename, 'w') as out:


### PR DESCRIPTION
/cc @brendandburns 

/hold
(until 5.0.0 released)

note that this pull will involve some critical dependency changes in the java repo.