### PR TITLE
Skip fetching swagger from upstream using `OPENAPI_SKIP_FETCH_SPEC` env

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -42,6 +42,7 @@ kubeclient::generator::generate_client() {
 
     OPENAPI_GENERATOR_USER_ORG="${OPENAPI_GENERATOR_USER_ORG:-OpenAPITools}"
     OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v3.3.4}"
+    OPENAPI_SKIP_FETCH_SPEC="${OPENAPI_SKIP_FETCH_SPEC:-}"
     USERNAME="${USERNAME:-kubernetes}"
     REPOSITORY="${REPOSITORY:-kubernetes}"
 
@@ -81,6 +82,7 @@ kubeclient::generator::generate_client() {
         -e PACKAGE_NAME="${PACKAGE_NAME}" \
         -e OPENAPI_GENERATOR_USER_ORG="${OPENAPI_GENERATOR_USER_ORG}" \
         -e OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT}" \
+        -e OPENAPI_SKIP_FETCH_SPEC="${OPENAPI_SKIP_FETCH_SPEC}" \
         -e USERNAME="${USERNAME}" \
         -e REPOSITORY="${REPOSITORY}" \
         -v "${output_dir}:/output_dir" \

--- a/openapi/swagger-codegen/client-generator.sh
+++ b/openapi/swagger-codegen/client-generator.sh
@@ -42,6 +42,7 @@ kubeclient::generator::generate_client() {
 
     SWAGGER_CODEGEN_USER_ORG="${SWAGGER_CODEGEN_USER_ORG:-swagger-api}"
     SWAGGER_CODEGEN_COMMIT="${SWAGGER_CODEGEN_COMMIT:-v2.2.3}"
+    OPENAPI_SKIP_FETCH_SPEC="${OPENAPI_SKIP_FETCH_SPEC:-}"
     USERNAME="${USERNAME:-kubernetes}"
     REPOSITORY="${REPOSITORY:-kubernetes}"
 
@@ -81,6 +82,7 @@ kubeclient::generator::generate_client() {
         -e PACKAGE_NAME="${PACKAGE_NAME}" \
         -e SWAGGER_CODEGEN_USER_ORG="${SWAGGER_CODEGEN_USER_ORG}" \
         -e SWAGGER_CODEGEN_COMMIT="${SWAGGER_CODEGEN_COMMIT}" \
+	-e OPENAPI_SKIP_FETCH_SPEC="${OPENAPI_SKIP_FETCH_SPEC}" \
         -e USERNAME="${USERNAME}" \
         -e REPOSITORY="${REPOSITORY}" \
         -v "${output_dir}:/output_dir" \


### PR DESCRIPTION
So that we can copy our own `swagger.json.unprocessed` (e.g. downloaded from openapi publishing) to generate clients.