### PR TITLE
Bugfix: Preserve field manager types for java client

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -142,7 +142,7 @@ def process_swagger(spec, client_language):
 
 def preserved_primitives_for_language(client_language):
     if client_language == "java":
-        return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
+        return ["intstr.IntOrString", "resource.Quantity", "v1.Patch", "v1.Fields"]
     elif client_language == "csharp":
         return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
     elif client_language == "haskell-http-client":


### PR DESCRIPTION
/cc @brendandburns 

a new type `v1.Fields` are introduced into ObjectMeta, we should preserve it or the generated type will be lang.Object

https://github.com/kubernetes-client/java/blob/dc82549dde1eeea7593203dec788af0fe33685a7/kubernetes/src/main/java/io/kubernetes/client/models/V1ManagedFieldsEntry.java#L37