### PR TITLE
Revert "preserve field manager types (#123)"

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -142,7 +142,7 @@ def process_swagger(spec, client_language):
 
 def preserved_primitives_for_language(client_language):
     if client_language == "java":
-        return ["intstr.IntOrString", "resource.Quantity", "v1.Patch", "v1.Fields"]
+        return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
     elif client_language == "csharp":
         return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
     elif client_language == "haskell-http-client":


### PR DESCRIPTION
This reverts commit f659d364ad6c7dda473780c6f69ad973a74cb6c5.


/cc @brendandburns 


per https://github.com/kubernetes/kubernetes/issues/79768

the type `v1.Fields` from openapi spec is supposed to be a "free-form" one but actually the generator considers it as a concrete object w/o properties ref https://github.com/kubernetes-client/java/pull/610/files#r303382853. this will break when we put some content into the field and try to deserialize it into a the type invalid type `v1.Fields` w/o usable properties 

revert the change to prevent the failure. 