### PR TITLE
Correct typescript library to use standard spelling on CRD property JSONPath

### DIFF
--- a/openapi/typescript.xml
+++ b/openapi/typescript.xml
@@ -32,6 +32,7 @@
                                 <supportsES6>false</supportsES6>
                                 <npmName>kubernetes-client-typescript</npmName>
                                 <npmVersion>${generator.client.version}</npmVersion>
+                                <modelPropertyNaming>original</modelPropertyNaming>
                             </configOptions>
                             <output>${generator.output.path}</output>
                         </configuration>


### PR DESCRIPTION
Closes: https://github.com/kubernetes-client/javascript/issues/305.

This closes the issue that you can not create a CRD with additional printer columns if you spell JSONPath correctly, as specified in the documentation. Before this change, you had to spell JSONPath as `jSONPath`.

This pr will fix that. It will also adjust 2 more properties: `Raw` of `RuntimeRawExtension` and `Port` of `V1DaemonEndpoint`. As a result, you can now use the same YAML definition with `kubectl` and this library, which failed previously.

Here the full patch after regenerating the typescript library:
```
diff --git a/src/api.ts b/src/api.ts
index 7401ecb..41952d6 100644
--- a/src/api.ts
+++ b/src/api.ts
@@ -2775,13 +2775,13 @@ export class RuntimeRawExtension {
     /**
     * Raw is the underlying serialization of this object.
     */
-    'raw': string;
+    'Raw': string;

     static discriminator: string | undefined = undefined;

     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "raw",
+            "name": "Raw",
             "baseName": "Raw",
             "type": "string"
         }    ];
@@ -5493,13 +5493,13 @@ export class V1DaemonEndpoint {
     /**
     * Port number of the given endpoint.
     */
-    'port': number;
+    'Port': number;

     static discriminator: string | undefined = undefined;

     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "port",
+            "name": "Port",
             "baseName": "Port",
             "type": "number"
         }    ];
@@ -20950,7 +20950,7 @@ export class V1beta1CustomResourceColumnDefinition {
     /**
     * JSONPath is a simple JSON path, i.e. with array notation.
     */
-    'jSONPath': string;
+    'JSONPath': string;
     /**
     * description is a human readable description of this column.
     */
@@ -20976,7 +20976,7 @@ export class V1beta1CustomResourceColumnDefinition {

     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "jSONPath",
+            "name": "JSONPath",
             "baseName": "JSONPath",
             "type": "string"
         },
```