### PR TITLE
Refactor: use provided value for dates haskell

### DIFF
--- a/openapi/haskell-http-client.xml
+++ b/openapi/haskell-http-client.xml
@@ -32,6 +32,7 @@
                                 <type-mappings>intstr.IntOrString=IntOrString,resource.Quantity=Quantity</type-mappings>
                                 <import-mappings>IntOrString=Kubernetes.OpenAPI.CustomTypes,Quantity=Kubernetes.OpenAPI.CustomTypes</import-mappings>
                                 <customTestInstanceModule>CustomInstances</customTestInstanceModule>
+                                <dateTimeFormat>%FT%T%6QZ</dateTimeFormat>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/openapi/haskell.sh
+++ b/openapi/haskell.sh
@@ -63,10 +63,6 @@ patch_cabal_file() {
         shift 2
     done
 }
-
-# Solve bug with date time format
-sed -i 's/formatISO8601Millis/formatISO8601Micros/g' ${OUTPUT_DIR}/lib/Kubernetes/OpenAPI/Core.hs
-
 patch_cabal_file "${CABAL_OVERRIDES[@]}"
 
 # Add license-file after license


### PR DESCRIPTION
This reverts the previous PR: https://github.com/kubernetes-client/gen/pull/127 Instead of using sed, it is using a custom parameter provided from the openapi generator.

