### PR TITLE
Fixes the wrong link auto-generation in the python generator

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -56,6 +56,7 @@ echo "--- Patching generated code..."
 find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i 's/\bclient/kubernetes.client/g' {} +
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/\bclient/kubernetes.client/g' {} +
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes.client-python/client-python/g' {} +
+find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes-kubernetes.client/kubernetes-client/g' {} +
 
 # fix imports
 find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.client./g' {} +


### PR DESCRIPTION
The change in this PR makes sure that all instances of `kubernetes-kubernetes.client` are replaced by `kubernetes-client`.

#### Brief Background

https://github.com/kubernetes-client/gen/blob/f14e0bb9de84a09644890a111f0c101759471bb0/openapi/python.sh#L57

The above line replaces all instances of `client` with `kubernetes.client` which has the side effect of changing `pip install git+https://github.com/kubernetes-client/python.git` to
`pip install git+https://github.com/kubernetes-kubernetes.client/python.git`.

#### References
- https://github.com/kubernetes-client/python/pull/931#discussion_r314434005
- https://github.com/kubernetes-client/python/issues/952#issuecomment-545972325

Fixes #133