### PR TITLE
[Java] Enforce custom mapping for patch object

### DIFF
--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -24,6 +24,8 @@
               <gitUserId>kubernetes-client</gitUserId>
               <gitRepoId>client-java</gitRepoId>
               <skipValidateSpec>true</skipValidateSpec>
+              <generateApiTests>false</generateApiTests>
+              <generateModelTests>false</generateModelTests>
               <configOptions>
                 <projectName>kubernetes-java-client</projectName>
                 <projectDescription>Java client for Kubernetes.</projectDescription>
@@ -47,8 +49,8 @@
                 <library>okhttp-gson</library>
                 <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
               </configOptions>
-              <typeMappings>int-or-string=IntOrString,quantity=Quantity</typeMappings>
-              <importMappings>IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity</importMappings>
+              <typeMappings>int-or-string=IntOrString,quantity=Quantity,patch=V1Patch</typeMappings>
+              <importMappings>IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity,V1Patch=io.kubernetes.client.custom.V1Patch</importMappings>
               <output>${generator.output.path}</output>
             </configuration>
           </execution>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -137,6 +137,7 @@ def process_swagger(spec, client_language):
     inline_primitive_models(spec, preserved_primitives_for_language(client_language))
 
     add_custom_formatting(spec, format_for_language(client_language))
+    add_custom_typing(spec, type_for_language(client_language))
 
     remove_models(spec, removed_models_for_language(client_language))
 
@@ -154,7 +155,13 @@ def preserved_primitives_for_language(client_language):
 
 def format_for_language(client_language):
     if client_language == "java":
-        return {"resource.Quantity": "quantity"}
+        return {"resource.Quantity": "quantity", "v1.Patch": "patch"}
+    else:
+        return {}
+
+def type_for_language(client_language):
+    if client_language == "java":
+        return {"v1.Patch": "string"}
     else:
         return {}
 
@@ -311,6 +318,12 @@ def add_custom_formatting(spec, custom_formats):
         if k not in custom_formats:
             continue
         v["format"] = custom_formats[k]
+
+def add_custom_typing(spec, custom_types):
+    for k, v in spec['definitions'].items():
+        if k not in custom_types:
+            continue
+        v["type"] = custom_types[k]
 
 def write_json(filename, object):
     with open(filename, 'w') as out:


### PR DESCRIPTION
the custom mapping for Patch object leaked when migrating to openapi-generator, this pull enforces java generator resolve custom patch object as the api parameter.