### PR TITLE
Make custom object spec's delete body optional

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -375,7 +375,6 @@
         {
           "name": "body",
           "in": "body",
-          "required": true,
           "schema": {
             "$ref": "#/definitions/v1.DeleteOptions"
           }
@@ -870,7 +869,6 @@
         {
           "name": "body",
           "in": "body",
-          "required": true,
           "schema": {
             "$ref": "#/definitions/v1.DeleteOptions"
           }


### PR DESCRIPTION
the "body" of delete API is actually optional. if the body is absent on delete call, kube-apiserver will be acquiring corresponding delete options from HTTP query parameters.