### PR TITLE
feat: switch python-asyncio to use openapi-generator v4.2.3

### DIFF
--- a/openapi/python-asyncio.sh
+++ b/openapi/python-asyncio.sh
@@ -45,6 +45,7 @@ source "${SETTING_FILE}"
 
 # use openapi-generator to generate library
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.2.3}"
 
 CLIENT_LANGUAGE=python-asyncio
 CLEANUP_DIRS=(client/apis client/models docs test)

--- a/openapi/python-asyncio.xml
+++ b/openapi/python-asyncio.xml
@@ -18,6 +18,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>${generator.spec.path}</inputSpec>
+                            <skipValidateSpec>true</skipValidateSpec>
                             <language>python</language>
                             <library>asyncio</library>
                             <gitUserId>kubernetes-client</gitUserId>


### PR DESCRIPTION
As a default we use openapi-generator v3.3.4 which was released in 2018. In this PR I switch `python-asyncio` to the latest version of generator v4.2.3.
I don't want to switch it globally because their changelog is very impressive with some breaking changes too. I encourage other maintainers to evaluate the upgrade before we switch it globally.

The new openapi-generator's schema validator can't work with our pre-processed schema so it has to be disabled (more info #145).

Thank you.

cc: @brendandburns  @roycaihw