### PR TITLE
Disable selinux checks for the client-generating container

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -74,7 +74,7 @@ kubeclient::generator::generate_client() {
     CLEANUP_DIRS_STRING="${CLEANUP_DIRS[@]}"
 
     echo "--- Running generator inside container..."
-    docker run --security-opt label:disable -u $(id -u) \
+    docker run --security-opt="label=disable" -u $(id -u) \
         -e CLEANUP_DIRS="${CLEANUP_DIRS_STRING}" \
         -e KUBERNETES_BRANCH="${KUBERNETES_BRANCH}" \
         -e CLIENT_VERSION="${CLIENT_VERSION}" \

--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -74,7 +74,7 @@ kubeclient::generator::generate_client() {
     CLEANUP_DIRS_STRING="${CLEANUP_DIRS[@]}"
 
     echo "--- Running generator inside container..."
-    docker run -u $(id -u) \
+    docker run --security-opt label:disable -u $(id -u) \
         -e CLEANUP_DIRS="${CLEANUP_DIRS_STRING}" \
         -e KUBERNETES_BRANCH="${KUBERNETES_BRANCH}" \
         -e CLIENT_VERSION="${CLIENT_VERSION}" \


### PR DESCRIPTION
When running client generation with selinux running, the generator won't have proper access to the `/output_dir` volume due to selinux checks. Adding the `--security-opt label:disable` will disable the selinux checks and allow client generation to succeed.