### PR TITLE
Add c generator

### DIFF
--- a/openapi/c.sh
+++ b/openapi/c.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARGC=$#
+
+if [ $# -ne 2 ]; then
+    echo "Usage:"
+    echo "  $(basename ${0}) OUTPUT_DIR SETTING_FILE_PATH"
+    echo "    Setting file should define KUBERNETES_BRANCH, CLIENT_VERSION, and PACKAGE_NAME"
+    echo "    Setting file can define an optional USERNAME if you're working on a fork"
+    echo "    Setting file can define an optional REPOSITORY if you're working on a ecosystem project"
+    exit 1
+fi
+
+
+OUTPUT_DIR=$1
+SETTING_FILE=$2
+mkdir -p "${OUTPUT_DIR}"
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+pushd "${SCRIPT_ROOT}" > /dev/null
+SCRIPT_ROOT=`pwd`
+popd > /dev/null
+
+pushd "${OUTPUT_DIR}" > /dev/null
+OUTPUT_DIR=`pwd`
+popd > /dev/null
+
+source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
+source "${SETTING_FILE}"
+
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-master}" \
+CLIENT_LANGUAGE=c; \
+CLEANUP_DIRS=(pkg); \
+kubeclient::generator::generate_client "${OUTPUT_DIR}"
+
+echo "---Done."

--- a/openapi/c.xml
+++ b/openapi/c.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.kubernetes</groupId>
+    <artifactId>client-c</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>client-c</name>
+    <url>http://kubernetes.io</url>
+    <build>
+        <plugins>
+            <plugin>
+		<groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <inputSpec>${generator.spec.path}</inputSpec>
+                            <generatorName>c</generatorName>
+                            <gitUserId>kubernetes-c</gitUserId>
+                            <gitRepoId>c</gitRepoId>
+                            <configOptions>
+                                <packageName>${generator.package.name}</packageName>
+                                <packageVersion>${generator.client.version}</packageVersion>
+                            </configOptions>
+                            <output>${generator.output.path}</output>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <!-- dependencies are needed for the client being generated -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-annotations-version}</version>
+        </dependency>
+    </dependencies>
+    <properties>
+        <swagger-annotations-version>1.5.0</swagger-annotations-version>
+        <maven-plugin-version>1.0.0</maven-plugin-version>
+
+        <!-- Default values for the generator parameters. -->
+        <generator.output.path>.</generator.output.path>
+        <generator.spec.path>swagger.json</generator.spec.path>
+        <generator.package.name>swagger_client</generator.package.name>
+        <generator.client.version>unversioned</generator.client.version>
+    </properties>
+</project>


### PR DESCRIPTION
To address the issue #132 , add c generator (c.sh and c.xml) to generate a c-libcurl client library for kubernetes

The branch of openapi-generator is "master", user can change it in c.sh
```
OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-master}"
```
or set an env variable.
e.g.
```
OPENAPI_GENERATOR_COMMIT=v4.2.3
```