### PR TITLE
Upgrade OpenAPI Generator version for python client generator

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -45,6 +45,7 @@ popd > /dev/null
 
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.3.0}"
 
 CLIENT_LANGUAGE=python; \
 CLEANUP_DIRS=(client/api client/apis client/models docs test); \

--- a/openapi/python.xml
+++ b/openapi/python.xml
@@ -21,6 +21,7 @@
                             <language>python</language>
                             <gitUserId>kubernetes-client</gitUserId>
                             <gitRepoId>python</gitRepoId>
+                            <skipValidateSpec>true</skipValidateSpec>
                             <configOptions>
                                 <packageName>${generator.package.name}</packageName>
                                 <packageVersion>${generator.client.version}</packageVersion>


### PR DESCRIPTION
Use v4.3.0 by default now using the OPENAPI_GENERATOR_COMMIT
variable. This can be overriden by specifying the same variable
in the SETTINGS_FILE

Also, set the `skipValidateSpec` parameter in `openapi/python.xml`
to work around
[this](https://github.com/kubernetes-client/gen/issues/145) bug.

/assign
/cc @roycaihw