### PR TITLE
Correct operationId on DELETE collection operations for custom objects

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -145,8 +145,8 @@
       }
     },
     "delete": {
-      "operationId": "deleteClusterCustomObject",
-      "description": "Deletes the specified cluster scoped custom object",
+      "operationId": "deleteCollectionClusterCustomObject",
+      "description": "Delete collection of cluster scoped custom objects",
       "consumes": [
         "*/*"
       ],
@@ -355,8 +355,8 @@
       }
     },
     "delete": {
-      "operationId": "deleteNamespacedCustomObject",
-      "description": "Deletes the specified namespace scoped custom object",
+      "operationId": "deleteCollectionNamespacedCustomObject",
+      "description": "Delete collection of namespace scoped custom objects",
       "consumes": [
         "*/*"
       ],


### PR DESCRIPTION
Fixes #152 and bug introduced in #150

Ref:
- https://github.com/kubernetes-client/gen/issues/131
- https://github.com/tomplus/kubernetes_asyncio/pull/99