### PR TITLE
Add typescript-jquery generator

### DIFF
--- a/openapi/typescript-jquery.sh
+++ b/openapi/typescript-jquery.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARGC=$#
+
+if [ $# -ne 2 ]; then
+    echo "Usage:"
+    echo "  $(basename ${0}) OUTPUT_DIR SETTING_FILE_PATH"
+    echo "    Setting file should define KUBERNETES_BRANCH, CLIENT_VERSION, and PACKAGE_NAME"
+    echo "    Setting file can define an optional USERNAME if you're working on a fork"
+    echo "    Setting file can define an optional REPOSITORY if you're working on a ecosystem project"
+    exit 1
+fi
+
+
+OUTPUT_DIR=$1
+SETTING_FILE=$2
+mkdir -p "${OUTPUT_DIR}"
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+pushd "${SCRIPT_ROOT}" > /dev/null
+SCRIPT_ROOT=`pwd`
+popd > /dev/null
+
+pushd "${OUTPUT_DIR}" > /dev/null
+OUTPUT_DIR=`pwd`
+popd > /dev/null
+
+source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
+source "${SETTING_FILE}"
+
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.0.3}"; \
+CLIENT_LANGUAGE=typescript-jquery; \
+CLEANUP_DIRS=(api model); \
+kubeclient::generator::generate_client "${OUTPUT_DIR}"

--- a/openapi/typescript-jquery.xml
+++ b/openapi/typescript-jquery.xml
@@ -1,0 +1,40 @@
+<project 
+    xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.kubernetes</groupId>
+    <artifactId>client-typescript-jquery</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <name>client-typescript-jquery</name>
+    <url>http://kubernetes.io</url>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${generator.spec.path}</inputSpec>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <generatorName>typescript-jquery</generatorName>
+                            <output>${generator.output.path}</output>
+                            <configOptions>
+                                <sortParamsByRequiredFlag>true</sortParamsByRequiredFlag>
+                                <supportsES6>true</supportsES6>
+                                <npmName>kubernetes-client-typescript-frontend</npmName>
+                                <npmVersion>${generator.client.version}</npmVersion>
+                                <modelPropertyNaming>original</modelPropertyNaming>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+


### PR DESCRIPTION
I need a Kubernetes client that can work in the browser, rather than NodeJS. 

I tested these as alternative generators:

- `typescript-axios` The generated code has naming conflicts for instance, `AutoscalingV2beta1` and `AutoscalingV2beta2` would export objects with the same name, causing the TypeScript compiler to error.
- `typescript-fetch` As with Axios

 In the end I stuck with `typescript-jquery` noting that [on the NodeJS client](https://github.com/kubernetes-client/javascript) that there is a plan to make a jQuery version. I believe this generator forms the start of that work. 

I used these settings to test the generation process [Gist](https://gist.github.com/d-cs/448b574b54a5ff757e1d4696880c1a78). 