### PR TITLE
Fixes CRD preprocess aborting

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -124,7 +124,7 @@ def clean_crd_meta(spec):
         if k.endswith('List'):
             print("Using built-in v1.ListMeta")
             v['properties']['metadata']['$ref'] = '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
-            v['properties']['metadata'].pop('properties')
+            v['properties']['metadata'].pop('properties', None)
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta', '#/definitions/v1.ListMeta')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta', '#/definitions/v1.ObjectMeta')
 


### PR DESCRIPTION
the preprocess script aborts when handling multiple CRDs w/ `KUBERNETES_CRD_GROUP_PREFIX` unset, this pull fixes the behavior. 

```
Making model `v1beta1.FederatedDeployment` inline as object...
Making model `v1beta1.FederatedTypeConfig` inline as object...
Using built-in v1.ListMeta
Using built-in v1.ListMeta
Using built-in v1.ListMeta
    out_spec = process_swagger(in_spec, args.client_language, crd_mode)
  File "//preprocess_spec.py", line 178, in process_swagger
    clean_crd_meta(spec)
  File "//preprocess_spec.py", line 127, in clean_crd_meta
    v['properties']['metadata'].pop('properties')
  File "/usr/lib/python2.7/collections.py", line 160, in pop
    raise KeyError(key)
KeyError: 'properties'
```