### PR TITLE
fix csharp generator missing model

### DIFF
--- a/openapi/csharp.xml
+++ b/openapi/csharp.xml
@@ -33,7 +33,6 @@
         <arguments>
           <argument>--max-old-space-size=8192</argument> <!-- fix oom -->
           <argument>/usr/bin/autorest</argument>
-          <argument>/output_dir/config.yaml</argument>
           <argument>--input-file=${generator.spec.path}</argument>
           <argument>--csharp</argument>
           <argument>--namespace=${generator.package.name}</argument>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -214,7 +214,13 @@ def format_for_language(client_language):
 
 def type_for_language(client_language):
     if client_language == "java":
-        return {"v1.Patch": "string"}
+        return {"v1.Patch": { "type": "string"}}
+    elif client_language == "csharp":
+        return {
+                "v1.Patch": { "type": "object", "properties": {"content": { "type": "object"}} }, 
+                "resource.Quantity": { "type": "object", "properties": {"value": { "type": "string"}} }, 
+                "intstr.IntOrString" : { "type": "object", "properties": {"value": { "type": "string"}} },
+               }
     else:
         return {}
 
@@ -389,7 +395,7 @@ def add_custom_typing(spec, custom_types):
     for k, v in spec['definitions'].items():
         if k not in custom_types:
             continue
-        v["type"] = custom_types[k]
+        v.update(custom_types[k])
 
 def add_openapi_codegen_x_implement_extension(spec, client_language):
     if client_language != "java":

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -117,6 +117,15 @@ def strip_401_response(operation, _):
         if len(operation['responses']) == 0:
             operation['responses']['200'] = { 'description': 'OK' }
 
+
+def transform_to_csharp_stream_response(operation, _):
+    if operation.get('operationId', None) == 'readNamespacedPodLog' or operation.get('x-kubernetes-action', None) == 'connect':
+        operation['responses']['200']["schema"] = {
+            "type": "object", 
+            "format": "file" ,
+        }
+
+
 def strip_tags_from_operation_id(operation, _):
     operation_id = operation['operationId']
     if 'tags' in operation:
@@ -162,6 +171,9 @@ def process_swagger(spec, client_language, crd_mode=False):
     if client_language == "csharp":
         # 401s in the spec block the csharp code generator from throwing on 401
         apply_func_to_spec_operations(spec, strip_401_response)
+
+        # force to autorest to generate stream
+        apply_func_to_spec_operations(spec, transform_to_csharp_stream_response)
 
     apply_func_to_spec_operations(spec, strip_delete_collection_operation_watch_params)
 


### PR DESCRIPTION
generator for
https://github.com/kubernetes-client/csharp/pull/505

this pr move removed autorest param to python preprocessor

```
-          <argument>--directive={from: "swagger-document", where: "$..*[?(@.consumes[0] === \"*/*\")]", transform: "$.consumes[0] = \"application/json\""}</argument>
-          <argument>--directive={from: "swagger-document", where: "$..*[?(@.operationId === \"readNamespacedPodLog\")]", transform: "$.responses[\"200\"].schema = { \"type\": \"object\", \"format\": \"file\" }"}</argument>
-          <argument>--directive={from: "swagger-document", where: "$..*[?(@[\"x-kubernetes-action\"]=== \"proxy\")]", transform: "$.responses[\"200\"].schema = { \"type\": \"object\", \"format\": \"file\" }"}</argument>
-          <argument>--directive={from: "swagger-document", where: "$.definitions", transform: "$[\"intstr.IntOrString\"] = {\"properties\": { \"value\": { \"type\": \"string\" }}}"}</argument>
-          <argument>--directive={from: "swagger-document", where: "$.definitions", transform: "$[\"resource.Quantity\"] = {\"properties\": { \"value\": { \"type\": \"string\" }}}"}</argument>
-          <argument>--directive={from: "swagger-document", where: "$.definitions", transform: "$[\"v1.Patch\"] = {\"properties\": { \"content\": { \"type\": \"object\" }}}"}</argument>
```


```
-          <argument>--directive={from: "swagger-document", where: "$..*[?(@.consumes[0] === \"*/*\")]", transform: "$.consumes[0] = \"application/json\""}</argument>
```
was ignored since it no longer blocks autorest