### PR TITLE
Add io.k8s.api.autoscaling.v1.Scale to Java gen

### DIFF
--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -37,6 +37,7 @@
                     V1Patch=io.kubernetes.client.custom.V1Patch,
                     V1DeleteOptions=io.kubernetes.client.openapi.models.V1DeleteOptions,
                     V1Status=io.kubernetes.client.openapi.models.V1Status,
+                    V1Scale=io.kubernetes.client.openapi.models.V1Scale,
                   </importMappings>
                   <configOptions>
                     <invokerPackage>io.kubernetes.client.openapi</invokerPackage>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -147,6 +147,7 @@ def clean_crd_meta(spec):
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status', '#/definitions/v1.Status')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Patch', '#/definitions/v1.Patch')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions', '#/definitions/v1.DeleteOptions')
+        find_rename_ref_recursive(spec, '#/definitions/io.k8s.api.autoscaling.v1.Scale', '#/definitions/v1.Scale')
 
 
 def add_custom_objects_spec(spec):


### PR DESCRIPTION
Similarly to https://github.com/kubernetes-client/gen/pull/176, this PR adds required to types to create a valid Java client.
In this case, adds the v1.scale type required for clients that need to implement `scale` resource https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource.