### PR TITLE
Custom objects spec: Add allowWatchBookmarks, resoureVersionMatch parameters

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -48,6 +48,13 @@
       ],
       "parameters": [
         {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "type": "boolean",
+          "uniqueItems": true
+        },
+        {
           "uniqueItems": true,
           "type": "string",
           "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
@@ -81,6 +88,13 @@
           "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
           "name": "resourceVersion",
           "in": "query"
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "type": "string",
+          "uniqueItems": true
         },
         {
           "uniqueItems": true,
@@ -279,6 +293,13 @@
       ],
       "parameters": [
         {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "type": "boolean",
+          "uniqueItems": true
+        },
+        {
           "uniqueItems": true,
           "type": "string",
           "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
@@ -312,6 +333,13 @@
           "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
           "name": "resourceVersion",
           "in": "query"
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "type": "string",
+          "uniqueItems": true
         },
         {
           "uniqueItems": true,


### PR DESCRIPTION
- `allowWatchBookmarks` was [introduced in Kubernetes 1.15](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#alpha) (in alpha mode) as part of the [watch bookmarks feature](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks) and promoted to stable in [Kubernetes 1.17](https://v1-17.docs.kubernetes.io/docs/setup/release/notes/#stable)
- `resourceVersionMatch` seems to be have been introduced [in Kubernetes 1.19](https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter)

Opening the PR here because these fields are missing in the .NET Kubernetes client, this will then hopefully flow to the .NET client.