### PR TITLE
Fix for issue #181 - use host networking on container

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -79,7 +79,7 @@ kubeclient::generator::generate_client() {
     CLEANUP_DIRS_STRING="${CLEANUP_DIRS[@]}"
 
     echo "--- Running generator inside container..."
-    docker run --security-opt="label=disable" -u $(id -u) \
+    docker run --security-opt="label=disable" -u $(id -u) --network host \
         -e CLEANUP_DIRS="${CLEANUP_DIRS_STRING}" \
         -e KUBERNETES_BRANCH="${KUBERNETES_BRANCH}" \
         -e CLIENT_VERSION="${CLIENT_VERSION}" \


### PR DESCRIPTION
An approach to fix issue #181 is to use host networking on the container run by client-generator.sh. With this change was able to generate the models as suggested by [here](https://github.com/kubernetes-client/java/blob/master/docs/generate-model-from-third-party-resources.md