### PR TITLE
Add hideGenerationTimestamp & library options for Java

### DIFF
--- a/openapi/java-crd-cmd.sh
+++ b/openapi/java-crd-cmd.sh
@@ -2,9 +2,11 @@
 
 PACKAGE_NAME=${PACKAGE_NAME:-io.kubernetes.client}
 CLIENT_VERSION=${CLIENT_VERSION:-5.0-SNAPSHOT}
-GENERATE_APIS=${GENERATE_APIS:false}
+GENERATE_APIS=${GENERATE_APIS:-false}
 OUTPUT_DIR=${OUTPUT_DIR:-java}
 OPENAPI_MODEL_LENGTH=${OPENAPI_MODEL_LENGTH:-}
+HIDE_GENERATION_TIMESTAMP=${HIDE_GENERATION_TIMESTAMP:-false}
+LIBRARY=${LIBRARY:-okhttp-gson}
 OPENAPI_SKIP_BASE_INTERFACE=
 KUBERNETES_CRD_GROUP_PREFIX=
 
@@ -17,12 +19,16 @@ print_usage() {
   echo " -p: the base package name of the generated java project. " >& 2
   echo " -o: output directory of the generated java project. " >& 2
   echo " -l: keep the n last segments for the generated class name. " >& 2
+  echo " -h: hide generation timestamp" >& 2
+  echo " -i: client library" >& 2
 }
 
-while getopts 'c:g:n:l:p:o:x' flag; do
+while getopts 'c:g:h:i:n:l:p:o:x' flag; do
   case "${flag}" in
     c) CLIENT_VERSION="${CLIENT_VERSION}" ;;
     g) GENERATE_APIS="${OPTARG}" ;;
+    h) HIDE_GENERATION_TIMESTAMP="${OPTARG}" ;;
+    i) LIBRARY="${OPTARG}" ;;
     n) KUBERNETES_CRD_GROUP_PREFIX="${OPTARG}" ;;
     l) OPENAPI_MODEL_LENGTH="${OPTARG}" ;;
     p) PACKAGE_NAME="${OPTARG}" ;;
@@ -39,6 +45,8 @@ echo "PACKAGE_NAME: $PACKAGE_NAME" >& 2
 echo "GENERATE_APIS: $GENERATE_APIS" >& 2
 echo "CLIENT_VERSION: $CLIENT_VERSION" >& 2
 echo "OUTPUT_DIR: $OUTPUT_DIR" >& 2
+echo "HIDE_GENERATION_TIMESTAMP: $HIDE_GENERATION_TIMESTAMP" >& 2
+echo "LIBRARY: $LIBRARY" >& 2
 echo "" >& 2 # empty line
 
 
@@ -67,4 +75,6 @@ OPENAPI_SKIP_FETCH_SPEC=true \
 OPENAPI_MODEL_LENGTH=${OPENAPI_MODEL_LENGTH} \
 KUBERNETES_CRD_GROUP_PREFIX=${KUBERNETES_CRD_GROUP_PREFIX} \
 OPENAPI_SKIP_BASE_INTERFACE=${OPENAPI_SKIP_BASE_INTERFACE} \
+HIDE_GENERATION_TIMESTAMP=${HIDE_GENERATION_TIMESTAMP} \
+LIBRARY=${LIBRARY} \
 $(pwd)/java.sh ${OUTPUT_DIR} /tmp/settings

--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -87,10 +87,10 @@
                 <serializableModel>false</serializableModel>
                 <bigDecimalAsString>false</bigDecimalAsString>
                 <fullJavaUtil>false</fullJavaUtil>
-                <hideGenerationTimestamp>false</hideGenerationTimestamp>
+                <hideGenerationTimestamp>${env.HIDE_GENERATION_TIMESTAMP}</hideGenerationTimestamp>
                 <dateLibrary>java8</dateLibrary>
                 <useRxJava>false</useRxJava>
-                <library>okhttp-gson</library>
+                <library>${env.LIBRARY}</library>
                 <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
               </configOptions>
               <typeMappings>int-or-string=IntOrString,quantity=Quantity,patch=V1Patch</typeMappings>

--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -48,6 +48,7 @@ kubeclient::generator::generate_client() {
     KUBERNETES_CRD_MODE="${KUBERNETES_CRD_MODE:-}"
     KUBERNETES_CRD_GROUP_PREFIX="${KUBERNETES_CRD_GROUP_PREFIX:-}"
     GENERATE_APIS="${GENERATE_APIS:-true}"
+    HIDE_GENERATION_TIMESTAMP="${HIDE_GENERATION_TIMESTAMP:-false}"
     USERNAME="${USERNAME:-kubernetes}"
     REPOSITORY="${REPOSITORY:-kubernetes}"
 
@@ -93,6 +94,8 @@ kubeclient::generator::generate_client() {
         -e KUBERNETES_CRD_GROUP_PREFIX="${KUBERNETES_CRD_GROUP_PREFIX}" \
         -e GENERATE_APIS="${GENERATE_APIS}" \
         -e OPENAPI_SKIP_BASE_INTERFACE="${OPENAPI_SKIP_BASE_INTERFACE}" \
+        -e HIDE_GENERATION_TIMESTAMP="${HIDE_GENERATION_TIMESTAMP}" \
+        -e LIBRARY="${LIBRARY}" \
         -e USERNAME="${USERNAME}" \
         -e REPOSITORY="${REPOSITORY}" \
         -v "${output_dir}:/output_dir" \


### PR DESCRIPTION
This PR exposes the `hideGenerationTimestamp` and `library`.
Given the limitation for the cli options, I used `h`for `hideGenerationTimestamp` and `i` for `library`.