### PR TITLE
default LIBRARY to okhttp-gson

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -51,6 +51,8 @@ kubeclient::generator::generate_client() {
     HIDE_GENERATION_TIMESTAMP="${HIDE_GENERATION_TIMESTAMP:-false}"
     USERNAME="${USERNAME:-kubernetes}"
     REPOSITORY="${REPOSITORY:-kubernetes}"
+    # LIBRARY is used by Java client generation.
+    LIBRARY="${LIBRARY:-okhttp-gson}"
 
     local output_dir=$1
     pushd "${output_dir}" > /dev/null


### PR DESCRIPTION
Ran into `gen/openapi/openapi-generator/client-generator.sh: line 83: LIBRARY: unbound variable` when I was generating the python client https://github.com/kubernetes-client/python/pull/1411. It seems the env is only used by `java.xml`. 

The naming could use some improvement, and maybe the defaulting in https://github.com/kubernetes-client/gen/blob/master/openapi/java-crd-cmd.sh#L9 is no longer needed. But this should unblock the other clients. 

/cc @abelsromero