### PR TITLE
support macos

### DIFF
--- a/proto/install.sh
+++ b/proto/install.sh
@@ -17,7 +17,13 @@
 echo 'Installing proto compiler'
 
 version=3.6.1
-file=protoc-${version}-linux-x86_64.zip
+platform="linux"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    platform="osx"
+fi
+
+file=protoc-${version}-${platform}-x86_64.zip
 
 wget https://github.com/google/protobuf/releases/download/v${version}/${file}
 unzip ${file}


### PR DESCRIPTION
Fix `./proto/generate.sh: line 93: ./bin/protoc: cannot execute binary file: Exec format` in macOS

![image](https://user-images.githubusercontent.com/20190812/121120288-d6675580-c84f-11eb-95df-39f1e015a353.png)
