### PR TITLE
Append value to x-implements in preprocess_spec.py to allow for customization

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -464,9 +464,13 @@ def add_openapi_codegen_x_implement_extension(spec, client_language):
         if "metadata" not in v['properties']:
             continue # not a legitimate kubernetes api object
         if v["properties"]["metadata"]["$ref"] == "#/definitions/v1.ListMeta":
-            v["x-implements"] = ["io.kubernetes.client.common.KubernetesListObject"]
+            if "x-implements" not in v:
+                v["x-implements"] = []
+            v["x-implements"].append("io.kubernetes.client.common.KubernetesListObject")
         elif v["properties"]["metadata"]["$ref"] == "#/definitions/v1.ObjectMeta":
-            v["x-implements"] = ["io.kubernetes.client.common.KubernetesObject"]
+            if "x-implements" not in v:
+                v["x-implements"] = []
+            v["x-implements"].append("io.kubernetes.client.common.KubernetesObject")
 
 
 


### PR DESCRIPTION
I'm working on customizing CRD model generator by adding my own interfaces to the generated model classes. However, the preprocess_spec.py currently overwrites and modifications/customization I performed on the openApi spec. This change addresses this issue by having the preprocess_spec.py add to the x-implements list if exists or else create it.