### PR TITLE
Update the base image version to 3.8.2.

### DIFF
--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM maven:3.5-jdk-8-slim
+FROM maven:3.8.2-jdk-8-slim
 
 # Install Autorest
-RUN apt-get update && apt-get -qq -y install libunwind8 libicu57 libssl1.0 liblttng-ust0 libcurl3 libuuid1 libkrb5-3 zlib1g
+RUN apt-get update && apt-get -qq -y install libunwind8 libicu67 libssl1.0 liblttng-ust0 libcurl4 libuuid1 libkrb5-3 zlib1g
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get -y install \
     nodejs \
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 # Install preprocessing script requirements
-RUN apt-get update && apt-get -y install git python-pip && pip install urllib3==1.24.2
+RUN apt-get update && apt-get -y install git python3-pip && pip install urllib3==1.24.2
 
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/

--- a/openapi/openapi-generator/generate_client_in_container.sh
+++ b/openapi/openapi-generator/generate_client_in_container.sh
@@ -79,7 +79,7 @@ popd
 mkdir -p "${output_dir}"
 
 echo "--- Downloading and pre-processing OpenAPI spec"
-python "${SCRIPT_ROOT}/preprocess_spec.py" "${CLIENT_LANGUAGE}" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json" "${USERNAME}" "${REPOSITORY}"
+python3 "${SCRIPT_ROOT}/preprocess_spec.py" "${CLIENT_LANGUAGE}" "${KUBERNETES_BRANCH}" "${output_dir}/swagger.json" "${USERNAME}" "${REPOSITORY}"
 
 echo "--- Cleaning up previously generated folders"
 for i in ${CLEANUP_DIRS}; do


### PR DESCRIPTION
As reported there, seemingly this image has the CA file which is
probably old enough so that fetching resources for nodejs
installation fails due to certificate verification.

This primarily update the version to 3.8.2, the latest one.
Some installed package names have change since then; most notably
it's switched to python3. Fortunately the current code seems
working just fine but the command names need to be renamed.