### PR TITLE
remove csharp versioning todo

### DIFF
--- a/openapi/csharp.xml
+++ b/openapi/csharp.xml
@@ -30,20 +30,6 @@
           </configuration>
         </execution>      
         <execution>
-          <id>prepare cp</id>
-          <phase>generate-sources</phase>
-          <goals>
-            <goal>exec</goal>
-          </goals>
-          <configuration>
-            <executable>cp</executable>
-            <arguments>
-              <argument>/tmp/csrepo/src/KubernetesClient/Versioning/VersionConverter.cs</argument>
-              <argument>/Versioning</argument>
-            </arguments>
-          </configuration>
-        </execution>        
-        <execution>
           <id>generate</id>
           <phase>generate-sources</phase>
           <goals>

--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -57,7 +57,4 @@ COPY preprocess_spec.py /
 COPY custom_objects_spec.json /
 COPY ${GENERATION_XML_FILE} /generation_params.xml
 
-# TODO bolian remove after C# generator stop reading ../version 
-RUN mkdir /Versioning && chmod -R go+rwx /Versioning
-
 ENTRYPOINT ["mvn-entrypoint.sh", "/generate_client.sh"]


### PR DESCRIPTION
versioning converter moved to a separated step because it depends on current `versioncoverter.cs` and have to be done manually.