### PR TITLE
add openapi-generator v5.x support to python client

### DIFF
--- a/openapi/python.xml
+++ b/openapi/python.xml
@@ -19,6 +19,7 @@
                         <configuration>
                             <inputSpec>${generator.spec.path}</inputSpec>
                             <language>python</language>
+                            <generatorName>python</generatorName>
                             <gitUserId>kubernetes-client</gitUserId>
                             <gitRepoId>python</gitRepoId>
                             <skipValidateSpec>true</skipValidateSpec>


### PR DESCRIPTION
related to #207, 
this PR makes python client ready to openapi-generator v5.x.