### PR TITLE
add typescript three plus

### DIFF
--- a/openapi/typescript-fetch.xml
+++ b/openapi/typescript-fetch.xml
@@ -29,6 +29,7 @@
                             <configOptions>
                                 <sortParamsByRequiredFlag>true</sortParamsByRequiredFlag>
                                 <supportsES6>true</supportsES6>
+                                <typescriptThreePlus>true</typescriptThreePlus>
                                 <prefixParameterInterfaces>true</prefixParameterInterfaces>
                                 <npmName>kubernetes-client-typescript-fetch</npmName>
                                 <npmVersion>${generator.client.version}</npmVersion>


### PR DESCRIPTION
Add typescript three plus config option to typescript-fetch. This will fix errors around API changes in 3.6+ versions of TypeScript (3.6 has been out since August 2019). There's currently an open PR to make this change the default but the last update on that was in August. <sup>[1](https://github.com/OpenAPITools/openapi-generator/issues/9973)</sup>