### PR TITLE
Revert "Add handling of IntOrString for other typescript variations. …

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -235,9 +235,7 @@ def preserved_primitives_for_language(client_language):
         return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
     elif client_language == "haskell-http-client":
         return ["intstr.IntOrString", "resource.Quantity"]
-    elif client_language.startswith("typescript"):
-        # Checking with the prefix because there are variations of
-        # typescript generators (e.g. typescript-fetch, typescript-jquery).
+    elif client_language == "typescript":
         return ["intstr.IntOrString"]
     elif client_language == "c":
         return ["intstr.IntOrString"]

--- a/openapi/typescript-fetch.xml
+++ b/openapi/typescript-fetch.xml
@@ -22,9 +22,6 @@
                             <inputSpec>${generator.spec.path}</inputSpec>
                             <skipValidateSpec>true</skipValidateSpec>
                             <generatorName>typescript-fetch</generatorName>
-                            <importMappings>
-                              IntOrString=../../types
-                            </importMappings>
                             <output>${generator.output.path}</output>
                             <configOptions>
                                 <sortParamsByRequiredFlag>true</sortParamsByRequiredFlag>
@@ -35,7 +32,6 @@
                                 <npmVersion>${generator.client.version}</npmVersion>
                                 <modelPropertyNaming>original</modelPropertyNaming>
                             </configOptions>
-                            <typeMappings>int-or-string=IntOrString</typeMappings>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Reverts kubernetes-client/gen#214

We are using TypeScript-Fetch in the [JavaScript client refactor](https://github.com/kubernetes-client/javascript/blob/master/FETCH_MIGRATION.md) and this commit breaks how we need to generate code. The generated code for this looks like 

```TypeScript
import {
    IntOrString,
    IntOrStringFromJSON,
    IntOrStringFromJSONTyped,
    IntOrStringToJSON,
} from './IntOrString';
```

and throws an error saying that IntOrString doesn't exist. These changes don't work because the TypeScript-fetch generator [doesn't support import mapping](https://github.com/OpenAPITools/openapi-generator/issues/10887). Until import mapping support is added, these additions will always throw an error.

This is the same problem defined in #217. 