### PR TITLE
Don't ignore resources in "io.k8s" group if the user has explicitly requested to generate models for these

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -311,12 +311,12 @@ def is_model_deprecated(m):
 def filter_api_group(spec):
     models = {}
     for k, v in spec['definitions'].items():
-        if k.startswith("io.k8s"):
-            print("Removing builtin Kubernetes Resource %s" %k)
-        elif not k.startswith(os.environ.get('KUBERNETES_CRD_GROUP_PREFIX')):
-            print("Ignoring Custom Resource %s" %k)
-        else:
+        if k.startswith(os.environ.get('KUBERNETES_CRD_GROUP_PREFIX')):
             models[k] = v
+        elif k.startswith("io.k8s"):
+            print("Removing builtin Kubernetes Resource %s" %k)
+        else:
+            print("Ignoring Custom Resource %s" %k)
     spec['definitions'] = models
 
 def remove_deprecated_models(spec):


### PR DESCRIPTION
Don't ignore resources starting with "io.k8s" if the user has explicitly requested to generate models for these.

This is needed in case the user needs to generate clients and models for
resources that are not built-in but, yet, their group prefix starts with
'io.k8s', such as the Volume Snapshot CRDs, which belong to group
'snapshot.storage.k8s.io'.

Signed-off-by: Grigoris Thanasoulas <gregth@arrikto.com>
