### PR TITLE
Typescript generator handles MicroTime as custom object in stead of Date object

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -236,7 +236,7 @@ def preserved_primitives_for_language(client_language):
     elif client_language == "haskell-http-client":
         return ["intstr.IntOrString", "resource.Quantity"]
     elif client_language == "typescript":
-        return ["intstr.IntOrString"]
+        return ["intstr.IntOrString", "v1.MicroTime"]
     elif client_language == "c":
         return ["intstr.IntOrString"]
     else:
@@ -256,6 +256,8 @@ def format_for_language(client_language):
 def type_for_language(client_language):
     if client_language == "java":
         return {"v1.Patch": { "type": "string"}}
+    elif client_language == "typescript":
+        return {"v1.MicroTime": { "type": "string", "format": "date-time-micro" }}
     elif client_language == "csharp":
         return {
                 "v1.Patch": { "type": "object", "properties": {"content": { "type": "object"}} },

--- a/openapi/typescript.xml
+++ b/openapi/typescript.xml
@@ -23,7 +23,7 @@
                             <skipValidateSpec>true</skipValidateSpec>
                             <generatorName>typescript</generatorName>
                             <importMappings>
-                              IntOrString=../../types
+                              IntOrString=../../types,V1MicroTime=../../types
                             </importMappings>
                             <output>${generator.output.path}</output>
                             <configOptions>
@@ -36,7 +36,7 @@
                                 <npmVersion>${generator.client.version}</npmVersion>
                                 <modelPropertyNaming>original</modelPropertyNaming>
                             </configOptions>
-                            <typeMappings>int-or-string=IntOrString</typeMappings>
+                            <typeMappings>int-or-string=IntOrString,date-time-micro=V1MicroTime</typeMappings>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Some Kubernetes objects expect to have date fields represented RFC3339 format with microsecond.
However, Kubernetes is unable to represent microsecond field in openapi schema.
https://github.com/kubernetes/kubernetes/issues/97904
Therefore, make Typescript generator handle MicroTime as custom object in stead of Date object.

ref: https://github.com/kubernetes-client/javascript/pull/830