### PR TITLE
Fix issue with apimachinery v2 models [#220]

### DIFF
--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -32,12 +32,16 @@
                   <importMappings>
                     V1ListMeta=io.kubernetes.client.openapi.models.V1ListMeta,
                     V1ObjectMeta=io.kubernetes.client.openapi.models.V1ObjectMeta,
+                    V1ObjectMeta_v2=io.kubernetes.client.openapi.models.V1ObjectMeta,
                     IntOrString=io.kubernetes.client.custom.IntOrString,
                     Quantity=io.kubernetes.client.custom.Quantity,
                     V1Patch=io.kubernetes.client.custom.V1Patch,
                     V1DeleteOptions=io.kubernetes.client.openapi.models.V1DeleteOptions,
+                    V1DeleteOptions_v2=io.kubernetes.client.openapi.models.V1DeleteOptions,
                     V1Status=io.kubernetes.client.openapi.models.V1Status,
+                    V1Status_v2=io.kubernetes.client.openapi.models.V1Status,
                     V1Scale=io.kubernetes.client.openapi.models.V1Scale,
+                    V1Scale_v2=io.kubernetes.client.openapi.models.V1Scale,
                   </importMappings>
                   <configOptions>
                     <invokerPackage>io.kubernetes.client.openapi</invokerPackage>

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -144,10 +144,14 @@ def clean_crd_meta(spec):
             v['properties']['metadata'].pop('properties', None)
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta', '#/definitions/v1.ListMeta')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta', '#/definitions/v1.ObjectMeta')
+        find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2', '#/definitions/v1.ObjectMeta')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status', '#/definitions/v1.Status')
+        find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status_v2', '#/definitions/v1.Status')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Patch', '#/definitions/v1.Patch')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions', '#/definitions/v1.DeleteOptions')
+        find_rename_ref_recursive(spec, '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2', '#/definitions/v1.DeleteOptions')
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.api.autoscaling.v1.Scale', '#/definitions/v1.Scale')
+        find_rename_ref_recursive(spec, '#/definitions/io.k8s.api.autoscaling.v1.Scale_v2', '#/definitions/v1.Scale')
 
 
 def add_custom_objects_spec(spec):


### PR DESCRIPTION
As highlighted in #220 and https://github.com/kubernetes-client/java/issues/1710, when generating java models on kind 1.20+ clusters, the generated code may include imports to certain `v2` classes that do not exist. 
E.g. `my.custom.package.IoK8sApimachineryPkgApisMetaV1DeleteOptionsV2`. 

I noticed similar references to these classes in the codebase and updated them to include the `v2` ones.