### PR TITLE
Show progress of repo cloning

### DIFF
--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -24,7 +24,7 @@ ARG OPENAPI_GENERATOR_USER_ORG=OpenAPITools
 # Check out specific commit of openapi-generator
 RUN mkdir /source && \
     cd /source && \
-    git clone -n https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
+    git clone --progress -n https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
     cd openapi-generator && \
     git checkout $OPENAPI_GENERATOR_COMMIT
 


### PR DESCRIPTION
Show the progress of 'git clone' command so that it is apparent the command is running and the program is not stuck. This is especially helpful if the user is running on a slow internet connection, since the `openapi-generator` repo is ~1Gb.

Signed-off-by: Grigoris Thanasoulas <gregth@arrikto.com>