### PR TITLE
Add get_api_resources to the custom objects API

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -1,4 +1,49 @@
 {
+  "/apis/{group}/{version}": {
+    "parameters": [
+      {
+        "name": "group",
+        "in": "path",
+        "required": true,
+        "description": "The custom resource's group name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "in": "path",
+        "required": true,
+        "description": "The custom resource's version",
+        "type": "string"
+      }
+    ],
+    "get": {
+      "operationId": "getCustomObjectsAPIResources",
+      "description": "get available resources",
+      "tags": [
+        "custom_objects"
+      ],
+      "consumes": [
+        "*/*"
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "schemes": [
+        "https"
+      ],
+      "responses": {
+        "200": {
+          "description": "OK",
+          "schema": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+          }
+        },
+        "401": {
+          "description": "Unauthorized"
+        }
+      }
+    }
+  },
   "/apis/{group}/{version}/{plural}": {
     "parameters": [
       {
@@ -1012,7 +1057,7 @@
           "schema": {
             "type": "object"
           }
-          },
+        },
         "401": {
           "description": "Unauthorized"
         }


### PR DESCRIPTION
The custom objects API spec did not expose `GET /apis/{group}/{version}` whereas most of the built-in APIs do (as get_api_resources()). This change adds the getCustomObjectsAPIResources operation to the custom objects API spec, which will expose `GET /apis/{group}/{version}` for arbitrary custom resources (as `get_api_resources(group, version)` in generated clients).

Fixes #231 