### PR TITLE
Fix the handling of IntOrString.

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -239,7 +239,7 @@ def preserved_primitives_for_language(client_language):
         return ["intstr.IntOrString", "resource.Quantity", "v1.Patch"]
     elif client_language == "haskell-http-client":
         return ["intstr.IntOrString", "resource.Quantity"]
-    elif client_language == "typescript":
+    elif client_language in ["typescript", "typescript-fetch"]:
         return ["intstr.IntOrString", "v1.MicroTime"]
     elif client_language == "c":
         return ["intstr.IntOrString"]

--- a/openapi/typescript-fetch.xml
+++ b/openapi/typescript-fetch.xml
@@ -32,6 +32,7 @@
                                 <npmVersion>${generator.client.version}</npmVersion>
                                 <modelPropertyNaming>original</modelPropertyNaming>
                             </configOptions>
+                            <typeMappings>int-or-string=IntOrString</typeMappings>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
IntOrString has been considered to be 'object' in typescript-fetch, but it should be specially handled. This allows a similar handling done in typescript.xml.

Note that typescript-fetch generator does not support importMapping configuration, so leave it as-is for now.