### PR TITLE
Fix python-crd-cmd.sh cli options and improve verbosity in preprocess

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -174,6 +174,7 @@ def drop_paths(spec):
         group_prefix_reversed = '.'.join(group_prefix.split('.')[::-1])
         for k, v in spec['paths'].items():
             if k.startswith('/apis/' + group_prefix_reversed):
+                print("Adding Custom Resource api path %s" %k)
                 paths[k] = v
             else:
                 print("Ignoring non Custom Resource api path %s" %k)
@@ -318,6 +319,7 @@ def filter_api_group(spec):
     models = {}
     for k, v in spec['definitions'].items():
         if k.startswith(os.environ.get('KUBERNETES_CRD_GROUP_PREFIX')):
+            print("Adding Custom Resource by prefix %s" %k)
             models[k] = v
         elif k.startswith("io.k8s"):
             print("Removing builtin Kubernetes Resource %s" %k)

--- a/openapi/python-crd-cmd.sh
+++ b/openapi/python-crd-cmd.sh
@@ -20,7 +20,7 @@ print_usage() {
   echo " -h: hide generation timestamp" >& 2
 }
 
-while getopts 'c:g:h:n:l:p:o' flag; do
+while getopts 'c:g:h:n:l:p:o:' flag; do
   case "${flag}" in
     c) CLIENT_VERSION="${CLIENT_VERSION}" ;;
     g) GENERATE_APIS="${OPTARG}" ;;

--- a/openapi/python-crd-cmd.sh
+++ b/openapi/python-crd-cmd.sh
@@ -22,7 +22,7 @@ print_usage() {
 
 while getopts 'c:g:h:n:l:p:o:' flag; do
   case "${flag}" in
-    c) CLIENT_VERSION="${CLIENT_VERSION}" ;;
+    c) CLIENT_VERSION="${OPTARG}" ;;
     g) GENERATE_APIS="${OPTARG}" ;;
     h) HIDE_GENERATION_TIMESTAMP="${OPTARG}" ;;
     n) KUBERNETES_CRD_GROUP_PREFIX="${OPTARG}" ;;


### PR DESCRIPTION
Last option "o" does not work because of missed colon. Also I added a bit verbosity for CRD filters in preprocessing, it helps with debugging.