### PR TITLE
Update revision of openapi generator for typescript

### DIFF
--- a/openapi/typescript.sh
+++ b/openapi/typescript.sh
@@ -46,7 +46,7 @@ popd > /dev/null
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.0.3}"; \
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v6.4.0}"; \
 CLIENT_LANGUAGE=typescript; \
 CLEANUP_DIRS=(api model); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"


### PR DESCRIPTION
Since `typescript` did not exist until `v5.0.0` of the openapi generator, the default revision for `typescript.sh` has been bumped to avoid build errors if `OPENAPI_GENERATOR_COMMIT` has not been explicitly set to a valid revision.

fixes #238 