### PR TITLE
Fixed error when PACKAGE_NAME is not 'client'.

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -60,8 +60,10 @@ find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md
 find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes-kubernetes.client/kubernetes-client/g' {} +
 
 # fix imports
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.client./g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes.client/g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/getattr(client\.models/getattr(kubernetes.client.models/g' {} +
+if [ "${PACKAGE_NAME}" = client ]; then
+    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.client./g' {} +
+    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes.client/g' {} +
+    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/getattr(client\.models/getattr(kubernetes.client.models/g' {} +
+fi
 
 echo "---Done."


### PR DESCRIPTION
When executing `python-crd-cmd.sh` with the `-n` option specifying the package name, an error occurs as shown below:

```
$ ./python-crd-cmd.sh -o <output_dir> -n <api_group> -p <package_name>
...
--- Patching generated code...
find: ‘<output_dir>/client/’: No such file or directory
```

This is because the `client` directory is not created when the `-n` option is explicitly specified (`client` is the default value of the `-n` option).
I fixed the error by checking package name before the `find` command.