### PR TITLE
Update preprocess_spec.py to handle if 'name' doesn't exist.

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -104,7 +104,7 @@ def strip_delete_collection_operation_watch_params(op, parent):
     params = []
     if 'parameters' in op:
         for i in range(len(op['parameters'])):
-            paramName = op['parameters'][i]['name']
+            paramName = op['parameters'][i].get('name', None)
             if paramName != WATCH_QUERY_PARAM_NAME and paramName != ALLOW_WATCH_BOOKMARKS_QUERY_PARAM_NAME:
                 params.append(op['parameters'][i])
     op['parameters'] = params


### PR DESCRIPTION
```sh
--- Downloading and pre-processing OpenAPI spec
/usr/local/lib/python3.9/dist-packages/urllib3/connectionpool.py:842: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  warnings.warn((
Traceback (most recent call last):
  File "//preprocess_spec.py", line 543, in <module>
    sys.exit(main())
  File "//preprocess_spec.py", line 537, in main
    out_spec = process_swagger(in_spec, args.client_language, crd_mode)
  File "//preprocess_spec.py", line 196, in process_swagger
    apply_func_to_spec_operations(spec, strip_delete_collection_operation_watch_params)
  File "//preprocess_spec.py", line 71, in apply_func_to_spec_operations
    if func(v[op], v, *params):
  File "//preprocess_spec.py", line 107, in strip_delete_collection_operation_watch_params
    paramName = op['parameters'][i]['name']
KeyError: 'name'
```

https://github.com/kubernetes-client/javascript/actions/runs/6214469452/job/16866433360