### PR TITLE
Use shallow clone for generator repo (20MB vs 1GB)

### DIFF
--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -24,8 +24,11 @@ ARG OPENAPI_GENERATOR_USER_ORG=OpenAPITools
 # Check out specific commit of openapi-generator
 RUN mkdir /source && \
     cd /source && \
-    git clone --progress -n https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
+    mkdir openapi-generator && \
     cd openapi-generator && \
+    git init && \
+    git remote add origin https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
+    git fetch --progress --depth=1 origin $OPENAPI_GENERATOR_COMMIT && \
     git checkout $OPENAPI_GENERATOR_COMMIT && \
     git config --system --add safe.directory /source/openapi-generator
 

--- a/openapi/openapi-generator/generate_client_in_container.sh
+++ b/openapi/openapi-generator/generate_client_in_container.sh
@@ -74,7 +74,6 @@ shopt -u nullglob
 # To make sure we can reproduce generation, we would also log code-gen exact commit
 pushd /source/openapi-generator
   OPENAPI_GENERATOR_COMMIT_ACTUAL=$(git rev-parse HEAD)
-  OPENAPI_GENERATOR_COMMIT_TAG="$(git describe --tags --exact-match HEAD)"
 popd
 
 mkdir -p "${output_dir}"
@@ -100,6 +99,5 @@ mvn -f "${SCRIPT_ROOT}/generation_params.xml" clean generate-sources \
 mkdir -p "${output_dir}/.openapi-generator"
 echo "Requested Commit/Tag : ${OPENAPI_GENERATOR_COMMIT}" > "${output_dir}/.openapi-generator/COMMIT"
 echo "Actual Commit        : ${OPENAPI_GENERATOR_COMMIT_ACTUAL}" >> "${output_dir}/.openapi-generator/COMMIT"
-echo "Actual Tag           : ${OPENAPI_GENERATOR_COMMIT_TAG}" >> "${output_dir}/.openapi-generator/COMMIT"
 
 echo "---Done."


### PR DESCRIPTION
Unsure if there's interest in this, but it significantly decreases the time it takes to run the generation. This is especially nice when iterating as the container image build will clone the generator repo every time the target commit changes.