### PR TITLE
Fix checking out newer OpenAPI generator tags

### DIFF
--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir /source && \
     git init && \
     git remote add origin https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
     git fetch --progress --depth=1 origin $OPENAPI_GENERATOR_COMMIT && \
-    git checkout $OPENAPI_GENERATOR_COMMIT && \
+    git checkout -b gen FETCH_HEAD && \
     git config --system --add safe.directory /source/openapi-generator
 
 # Build it and persist local repository


### PR DESCRIPTION
Checkout would fail with `pathspec 'v7.0.1' did not match any file(s) known to git` without this change.

Probably regressed in #251.