### PR TITLE
Fix kubernetes object assumption

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -513,11 +513,11 @@ def add_openapi_codegen_x_implement_extension(spec, client_language):
         if "x-kubernetes-group-version-kind" not in v:
             continue
         if k == "v1.Status":
-            # Status is explicitly exlucded because it's obviously not a list object
+            # Status is explicitly excluded because it's obviously not a list object,
             # but it has ListMeta.
             continue
-        if "metadata" not in v['properties']:
-            continue # not a legitimate kubernetes api object
+        if not all(k in v['properties'] for k in ["metadata", "kind", "apiVersion"]) or "$ref" not in v['properties']['metadata']:
+            continue  # not a legitimate kubernetes api object (imperfect assumption)
         if v["properties"]["metadata"]["$ref"] == "#/definitions/v1.ListMeta":
             if "x-implements" not in v:
                 v["x-implements"] = []


### PR DESCRIPTION
There's an issue in the script where from a list of objects the `preprocess_spec.py` tries to "guess" which object is a kubernetes object and which is a list.

It currently gets tripped up by argo-rollouts' CRDs (there's an object that has a metadata block but no $ref).

```yaml
definitions:
  io.argoproj.v1alpha1.Measurement:
    properties:
      metadata:
        description: Metadata stores additional metadata about this metric result, used by the different providers (e.g. kayenta run ID, job name)
        type: object
        additionalProperties:
          type: string
          default: ""
```