### PR TITLE
fix: unbound variable USE_SINGLE_PARAMETER

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -101,7 +101,7 @@ kubeclient::generator::generate_client() {
         -e LIBRARY="${LIBRARY}" \
         -e USERNAME="${USERNAME}" \
         -e REPOSITORY="${REPOSITORY}" \
-        -e USE_SINGLE_PARAMETER="${USE_SINGLE_PARAMETER}" \
+        -e USE_SINGLE_PARAMETER="${USE_SINGLE_PARAMETER:-}" \
         -v "${output_dir}:/output_dir" \
         "${image_name}" "/output_dir"
 


### PR DESCRIPTION
```shell
openapi/java.sh src/gen settings
...
openapi/openapi-generator/client-generator.sh: line 86: USE_SINGLE_PARAMETER: unbound variable
```

use default from pom if empty

introduced in #257