### PR TITLE
feat: add `GET listCustomObjectForAllNamespaces`

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -44,6 +44,131 @@
       }
     }
   },
+  "/apis/{group}/{version}/{plural}#‎": {
+    "parameters": [
+      {
+        "uniqueItems": true,
+        "type": "string",
+        "description": "If 'true', then the output is pretty printed.",
+        "name": "pretty",
+        "in": "query"
+      },
+      {
+        "name": "group",
+        "in": "path",
+        "required": true,
+        "description": "The custom resource's group name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "in": "path",
+        "required": true,
+        "description": "The custom resource's version",
+        "type": "string"
+      },
+      {
+        "name": "plural",
+        "in": "path",
+        "required": true,
+        "description": "The custom resource's plural name. For TPRs this would be lowercase plural kind.",
+        "type": "string"
+      }
+    ],
+    "get": {
+      "operationId": "listCustomObjectForAllNamespaces",
+      "description": "list or watch namespace scoped custom objects",
+      "tags": [
+        "custom_objects"
+      ],
+      "consumes": [
+        "*/*"
+      ],
+      "produces": [
+        "application/json",
+        "application/json;stream=watch"
+      ],
+      "schemes": [
+        "https"
+      ],
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "type": "boolean",
+          "uniqueItems": true
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "name": "continue",
+          "in": "query"
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "name": "fieldSelector",
+          "in": "query"
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "name": "labelSelector",
+          "in": "query"
+        },
+        {
+          "uniqueItems": true,
+          "type": "integer",
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "name": "limit",
+          "in": "query"
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+          "name": "resourceVersion",
+          "in": "query"
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "type": "string",
+          "uniqueItems": true
+        },
+        {
+          "uniqueItems": true,
+          "type": "integer",
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "name": "timeoutSeconds",
+          "in": "query"
+        },
+        {
+          "name": "watch",
+          "uniqueItems": true,
+          "type": "boolean",
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications.",
+          "in": "query"
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "OK",
+          "schema": {
+            "type": "object"
+          }
+        },
+        "401": {
+          "description": "Unauthorized"
+        }
+      }
+    }
+  },
   "/apis/{group}/{version}/{plural}": {
     "parameters": [
       {


### PR DESCRIPTION
for the API path `/apis/{group}/{version}/{plural}`. We define a new key `/apis/{group}/{version}/{plural}#[U+200E]` in `custom_objects_spec.json` to work around this limitation.

> OpenAPI defines a unique operation as a combination of a path and an HTTP
> method. This means that two GET or two POST methods for the same path are not
> allowed.

— https://swagger.io/docs/specification/paths-and-operations

We use the hair space empty character to visually hide this path param from the Swagger UI.

addresses #268

Work around was taken from [here][1].

[1]: https://github.com/OAI/OpenAPI-Specification/issues/182#issuecomment-771566673