### PR TITLE
Added annotationLibrary to java configuration

### DIFF
--- a/openapi/java.xml
+++ b/openapi/java.xml
@@ -104,6 +104,7 @@
                 <dateLibrary>java8</dateLibrary>
                 <useRxJava>false</useRxJava>
                 <useJakartaEe>true</useJakartaEe>
+                <annotationLibrary>swagger1</annotationLibrary>
                 <library>${env.LIBRARY}</library>
                 <useSingleRequestParameter>${use-single-parameter}</useSingleRequestParameter>
                 <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>


### PR DESCRIPTION
Closes #270 

Property `annotationLibrary` set to `swagger1` should solve issues with AOT Processor during native build.