### PR TITLE
Default to openapi-generator 7.10.0 in rust.sh

### DIFF
--- a/openapi/rust.sh
+++ b/openapi/rust.sh
@@ -46,6 +46,8 @@ popd > /dev/null
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v7.10.0}" \
+
 CLIENT_LANGUAGE=rust; \
 CLEANUP_DIRS=(docs lib); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"


### PR DESCRIPTION
The openapi-generator needs to be at least 5.2.0 to build properly, see this PR: https://github.com/OpenAPITools/openapi-generator/pull/9745.

This PR defaults to the current latest release (7.10.0). 