### PR TITLE
fix(typescript): enable importFileExtension option

### DIFF
--- a/openapi/typescript.xml
+++ b/openapi/typescript.xml
@@ -35,6 +35,7 @@
                                 <npmName>kubernetes-client-typescript</npmName>
                                 <npmVersion>${generator.client.version}</npmVersion>
                                 <modelPropertyNaming>original</modelPropertyNaming>
+                                <importFileExtension>.js</importFileExtension>
                             </configOptions>
                             <typeMappings>int-or-string=IntOrString,date-time-micro=V1MicroTime</typeMappings>
                         </configuration>


### PR DESCRIPTION
This commit updates the TypeScript generator options to include importFileExtension. This is done in order to support ESM in the JavaScript client, as ESM requires explicit extensions.

Refs: https://github.com/kubernetes-client/javascript/pull/2062