### PR TITLE
Fixes the typo in custom object swagger model

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -44,7 +44,7 @@
       }
     }
   },
-  "/apis/{group}/{version}/{plural}#‎": {
+  "/apis/{group}/{version}/{plural}": {
     "parameters": [
       {
         "uniqueItems": true,


### PR DESCRIPTION
Ref: https://github.com/kubernetes-client/java/issues/3890

This PR fixes a typo that fails `listCustomObjectForAllNamespaces` API call.

/cc @brendandburns 