### PR TITLE
Separate a new path parameter `resource_plural` to avoid key conflict

### DIFF
--- a/openapi/custom_objects_spec.json
+++ b/openapi/custom_objects_spec.json
@@ -44,7 +44,7 @@
       }
     }
   },
-  "/apis/{group}/{version}/{plural}": {
+  "/apis/{group}/{version}/{resource_plural}": {
     "parameters": [
       {
         "uniqueItems": true,
@@ -68,7 +68,7 @@
         "type": "string"
       },
       {
-        "name": "plural",
+        "name": "resource_plural",
         "in": "path",
         "required": true,
         "description": "The custom resource's plural name. For TPRs this would be lowercase plural kind.",


### PR DESCRIPTION
Some developers are confused by the "hairspace" character for the document-only `listCustomObjectForAllNamespaces` API model (Ref: https://github.com/kubernetes-client/java/issues/3890) as the generated API method is not callable, Hence this PR adopts an alternative workaround from: https://github.com/OAI/OpenAPI-Specification/issues/182#issuecomment-905328509

Here is an example of how the generated code looks like:

> https://github.com/yue9944882/java/pull/102

> https://github.com/yue9944882/java/blob/automated-generate-28b5822c/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/CustomObjectsApi.java#L3625

```
    /**
     *
     * list or watch namespace scoped custom objects
     * @param group The custom resource&#39;s group name (required)
     * @param version The custom resource&#39;s version (required)
     * @param resourcePlural The custom resource&#39;s plural name. For TPRs this would be lowercase plural kind. (required)
     * @return APIlistCustomObjectForAllNamespacesRequest
     * @http.response.details
     <table summary="Response Details" border="1">
        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
     </table>
     */
    public APIlistCustomObjectForAllNamespacesRequest listCustomObjectForAllNamespaces(String group, String version, String resourcePlural) {
        return new APIlistCustomObjectForAllNamespacesRequest(group, version, resourcePlural);
    }

```