### PR TITLE
Add raw openapi schema to typescript client

### DIFF
--- a/openapi/openapi-generator/client-generator.sh
+++ b/openapi/openapi-generator/client-generator.sh
@@ -83,6 +83,12 @@ kubeclient::generator::generate_client() {
     CLEANUP_DIRS_STRING="${CLEANUP_DIRS[@]}"
 
     echo "--- Running generator inside container..."
+    
+    local additional_args=()
+    if test -d "templates/${CLIENT_LANGUAGE}"; then
+        OPENAPI_TEMPLATE_DIR=$(realpath "templates/${CLIENT_LANGUAGE}")
+        additional_args+=("-v" "${OPENAPI_TEMPLATE_DIR}:/template")
+    fi
     docker run --rm --security-opt="label=disable" -u $(id -u) \
         -e CLEANUP_DIRS="${CLEANUP_DIRS_STRING}" \
         -e KUBERNETES_BRANCH="${KUBERNETES_BRANCH}" \
@@ -103,6 +109,7 @@ kubeclient::generator::generate_client() {
         -e REPOSITORY="${REPOSITORY}" \
         -e USE_SINGLE_PARAMETER="${USE_SINGLE_PARAMETER:-}" \
         -v "${output_dir}:/output_dir" \
+        "${additional_args[@]}" \
         "${image_name}" "/output_dir"
 
     echo "---Done."

--- a/openapi/templates/typescript/model/model.mustache
+++ b/openapi/templates/typescript/model/model.mustache
@@ -1,0 +1,117 @@
+{{! Modified copy from https://github.com/OpenAPITools/openapi-generator/blob/dfbe985db36e91acaa039358bb71f082dc9dd6c7/modules/openapi-generator/src/main/resources/typescript/model/model.mustache}}
+{{>licenseInfo}}
+{{#models}}
+{{#model}}
+{{#tsImports}}
+import { {{classname}} } from '{{filename}}{{importFileExtension}}';
+{{/tsImports}}
+import { HttpFile } from '../http/http{{importFileExtension}}';
+
+{{#description}}
+/**
+* {{{.}}}
+*/
+{{/description}}
+{{^isEnum}}
+{{#oneOf}}
+{{#-first}}{{>model/modelOneOf}}{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
+export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
+{{#vars}}
+{{#description}}
+    /**
+    * {{{.}}}
+    */
+{{/description}}
+    '{{name}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
+{{/vars}}
+
+    {{#discriminator}}
+    static {{#parent}}override {{/parent}}readonly discriminator: string | undefined = "{{discriminatorName}}";
+    {{/discriminator}}
+    {{^discriminator}}
+    static {{#parent}}override {{/parent}}readonly discriminator: string | undefined = undefined;
+    {{/discriminator}}
+    {{#hasDiscriminatorWithNonEmptyMapping}}
+
+    static {{#parent}}override {{/parent}}readonly mapping: {[index: string]: string} | undefined = {
+    {{#discriminator.mappedModels}}
+        "{{mappingName}}": "{{modelName}}",
+    {{/discriminator.mappedModels}}
+    };
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+
+    static {{#parent}}override {{/parent}}readonly mapping: {[index: string]: string} | undefined = undefined;
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+
+    {{^isArray}}
+    static {{#parent}}override {{/parent}}readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {{#vars}}
+        {
+            "name": "{{name}}",
+            "baseName": "{{baseName}}",
+            "type": "{{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}",
+            "format": "{{dataFormat}}"
+        }{{^-last}},
+        {{/-last}}
+        {{/vars}}
+    ];
+
+    static {{#parent}}override {{/parent}}getAttributeTypeMap() {
+        {{#parent}}
+        return super.getAttributeTypeMap().concat({{classname}}.attributeTypeMap);
+        {{/parent}}
+        {{^parent}}
+        return {{classname}}.attributeTypeMap;
+        {{/parent}}
+    }
+    {{/isArray}}
+
+    public constructor() {
+        {{#parent}}
+        super();
+        {{/parent}}
+        {{#allVars}}
+        {{#discriminatorValue}}
+        this.{{name}} = "{{discriminatorValue}}";
+        {{/discriminatorValue}}
+        {{/allVars}}
+        {{#discriminatorName}}
+        this.{{discriminatorName}} = "{{classname}}";
+        {{/discriminatorName}}
+    }
+
+    {{#modelJson}}
+    public static OPENAPI_SCHEMA = {{{.}}}
+    {{/modelJson}}
+}
+{{#hasEnums}}
+
+{{#vars}}
+{{#isEnum}}
+export enum {{classname}}{{enumName}} {
+    {{#allowableValues}}
+    {{#enumVars}}
+    {{name}} = {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+}
+{{/isEnum}}
+{{/vars}}
+
+{{/hasEnums}}
+{{/oneOf}}
+{{/isEnum}}
+{{#isEnum}}
+export enum {{classname}} {
+    {{#allowableValues}}
+    {{#enumVars}}
+    {{name}} = {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+}
+{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/openapi/typescript.xml
+++ b/openapi/typescript.xml
@@ -26,6 +26,7 @@
                               IntOrString=../../types,V1MicroTime=../../types
                             </importMappings>
                             <output>${generator.output.path}</output>
+                            <templateDirectory>/template</templateDirectory>
                             <configOptions>
                                 <sortParamsByRequiredFlag>true</sortParamsByRequiredFlag>
                                 <supportsES6>true</supportsES6>


### PR DESCRIPTION
ref: https://github.com/kubernetes-client/javascript/issues/2384

This PR adds the original raw openapi schema to the generated typescript models. This is required to include the Kubernetes specific extension `x-kubernetes-group-version-kind` that includes the group version and kind of the resource.

Only adding that field is not possible because the `modelJson` variable is a raw string that I was unable to correctly parse with mustache (the templating engine used by the openapi generator).

In order to use a dedicated template, the template was added to a new subfolder of the structure `openapi/templates/$CLIENT_TYPE`. That subfolder is automtically mounted to the generator container at `/template` if it is defined.
Doing it like makes it easy for other language to add templates in the future if required.


The newly generated modals look like this example of a `Secret` resource:
```typescript
// ...

/**
* Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
*/
export class V1Secret {
    /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
    'apiVersion'?: string;
    /**
    * Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
    */
    'data'?: { [key: string]: string; };
    /**
    * Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
    */
    'immutable'?: boolean;
    /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
    'kind'?: string;
    'metadata'?: V1ObjectMeta;
    /**
    * stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.
    */
    'stringData'?: { [key: string]: string; };
    /**
    * Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
    */
    'type'?: string;

    // ...

    public static OPENAPI_SCHEMA = {
  "type" : "object",
  "properties" : {
    "apiVersion" : {
      "type" : "string",
      "description" : "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
    },
    "data" : {
      "type" : "object",
      "additionalProperties" : {
        "pattern" : "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
        "type" : "string",
        "format" : "byte"
      },
      "description" : "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4"
    },
    "immutable" : {
      "type" : "boolean",
      "description" : "Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil."
    },
    "kind" : {
      "type" : "string",
      "description" : "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
    },
    "metadata" : {
      "$ref" : "#/components/schemas/v1.ObjectMeta"
    },
    "stringData" : {
      "type" : "object",
      "additionalProperties" : {
        "type" : "string"
      },
      "description" : "stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API."
    },
    "type" : {
      "type" : "string",
      "description" : "Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types"
    }
  },
  "description" : "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
  "x-kubernetes-group-version-kind" : [ {
    "group" : "",
    "kind" : "Secret",
    "version" : "v1"
  } ]
}
}
```

the formatting of the `OPENAPI_SCHEMA` is a bit broken because indentation is not possible via mustache.
An alternative would be to have the schema in a variable for readability. But not sure if this is worth adding on a anyway generated file.
e.g.
```
const schema = {
    foo: 1,
    bar: 2,
}

export class V1Secret {
    public static OPENAPI_SCHEMA = schema;
}
```