### PR TITLE
Bump openapi generator in java.sh

### DIFF
--- a/openapi/java.sh
+++ b/openapi/java.sh
@@ -49,7 +49,7 @@ popd > /dev/null
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
 
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v7.6.0}" \
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v7.13.0}" \
 CLIENT_LANGUAGE=java; \
 CLEANUP_DIRS=(docs src/test/java/io/kubernetes/client/openapi/apis src/main/java/io/kubernetes/client/openapi/apis src/main/java/io/kubernetes/client/openapi/models src/main/java/io/kubernetes/client/openapi/auth gradle); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"


### PR DESCRIPTION
`v7.13.0` includes this fix https://github.com/OpenAPITools/openapi-generator/pull/21115 which fixes this issue https://github.com/kubernetes-client/java/issues/4020