### PR TITLE
enable erasable syntax option for typescript generator

### DIFF
--- a/openapi/typescript.xml
+++ b/openapi/typescript.xml
@@ -36,6 +36,7 @@
                                 <npmVersion>${generator.client.version}</npmVersion>
                                 <modelPropertyNaming>original</modelPropertyNaming>
                                 <importFileExtension>.js</importFileExtension>
+                                <useErasableSyntax>true</useErasableSyntax>
                             </configOptions>
                             <typeMappings>int-or-string=IntOrString,date-time-micro=V1MicroTime</typeMappings>
                         </configuration>


### PR DESCRIPTION
enable upstream option from openapi-generator https://github.com/OpenAPITools/openapi-generator/pull/21560

closing the loop on https://github.com/kubernetes-client/javascript/pull/2302

will add put up another PR updating the commit on js client after this