### PR TITLE
Bump python generator to openapi-generator v6.6.0 (take 2)

### DIFF
--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -45,7 +45,7 @@ popd > /dev/null
 
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v4.3.0}"
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v6.6.0}"
 
 CLIENT_LANGUAGE=python; \
 CLEANUP_DIRS=(client/api client/apis client/models docs test); \

--- a/openapi/python.xml
+++ b/openapi/python.xml
@@ -18,7 +18,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>${generator.spec.path}</inputSpec>
-                            <generatorName>python</generatorName>
+                            <generatorName>python-legacy</generatorName>
                             <gitUserId>kubernetes-client</gitUserId>
                             <gitRepoId>python</gitRepoId>
                             <skipValidateSpec>true</skipValidateSpec>


### PR DESCRIPTION
Revert commit a3394c2d03bf1664f42e60d2cdf669fd0286d4f4, which reverted #286, now that client 1.35 has been released.
