### PR TITLE
Add apidiscovery_definitions.json to docker image

### DIFF
--- a/openapi/openapi-generator/Dockerfile
+++ b/openapi/openapi-generator/Dockerfile
@@ -41,6 +41,7 @@ RUN chmod -R go+rwx /root && umask 0 && cd /source/openapi-generator && \
 COPY openapi-generator/generate_client_in_container.sh /generate_client.sh
 COPY preprocess_spec.py /
 COPY custom_objects_spec.json /
+COPY apidiscovery_definitions.json /
 COPY ${GENERATION_XML_FILE} /generation_params.xml
 
 ENTRYPOINT ["mvn-entrypoint.sh", "/generate_client.sh"]


### PR DESCRIPTION
This new file `apidiscovery_definitions.json`, with the API Discovery definitions, has to be added to allow generating clients from the docker image.

Now it crashes:
```
Traceback (most recent call last):
  File "//preprocess_spec.py", line 611, in <module>
    sys.exit(main())
  File "//preprocess_spec.py", line 605, in main
    out_spec = process_swagger(in_spec, args.client_language, crd_mode)
  File "//preprocess_spec.py", line 239, in process_swagger
    spec = add_apidiscovery_definitions(spec)
  File "//preprocess_spec.py", line 179, in add_apidiscovery_definitions
    with open(APIDISCOVERY_DEFINITIONS_PATH, 'r') as apidiscovery_file:
FileNotFoundError: [Errno 2] No such file or directory: '//apidiscovery_definitions.json'
```