### PR TITLE
Generate Python client-go retry wiring

### DIFF
--- a/openapi/python-aio-client-go-retry-configuration.patch
+++ b/openapi/python-aio-client-go-retry-configuration.patch
@@ -1,0 +1,19 @@
+--- configuration.py
++++ configuration.py
+@@ -307,0 +308,16 @@
++        """
++        self.client_go_retries = False
++        """Enable Kubernetes client-go-compatible retry semantics.
++
++           When enabled, GET and HEAD requests are retried on responses with
++           a 429 or 5xx status code and a valid Retry-After header. The
++           retry ceiling is read from ``retries`` when set; otherwise it
++           follows the client-go default of at most 10 retries.
++        """
++        self.client_go_retry_backoff = None
++        """Backoff for Kubernetes client-go-compatible retries.
++
++           If unset, client-go-compatible GET and HEAD retries use the
++           client-go default retry ceiling with no additional client-side
++           delay beyond Retry-After. When set, ``retries`` still overrides
++           the retry ceiling if it is not None.

--- a/openapi/python-aio-client-go-retry-rest.patch
+++ b/openapi/python-aio-client-go-retry-rest.patch
@@ -2,8 +2,8 @@
 +++ rest.py
 @@ -15,0 +16,5 @@
 +from kubernetes.aio.utils.retry import (
-+    async_on_retry_after_error,
 +    is_retry_after_response,
++    on_retry_after_error,
 +    retry_after_backoff,
 +)
 @@ -39,0 +45 @@
@@ -22,7 +22,7 @@
 +                getattr(self.configuration, 'retries', None),
 +                getattr(self.configuration, 'client_go_retry_backoff', None),
 +            )
-+            r = await async_on_retry_after_error(
++            r = await on_retry_after_error(
 +                backoff, self._is_read_retryable,
 +                lambda: read_request(True))
 +        else:

--- a/openapi/python-aio-client-go-retry-rest.patch
+++ b/openapi/python-aio-client-go-retry-rest.patch
@@ -1,0 +1,56 @@
+--- rest.py
++++ rest.py
+@@ -15,0 +16,5 @@
++from kubernetes.aio.utils.retry import (
++    async_on_retry_after_error,
++    is_retry_after_response,
++    retry_after_backoff,
++)
+@@ -39,0 +45 @@
++        self.configuration = configuration
+@@ -159 +165,17 @@
+-        r = await self.pool_manager.request(**args)
++        async def read_request(check_retry_status=False):
++            response = await self.pool_manager.request(**args)
++            if check_retry_status and self._should_retry_response(response):
++                await self._raise_for_status(response)
++            return response
++
++        if (method in ['GET', 'HEAD'] and _preload_content and
++                getattr(self.configuration, 'client_go_retries', False)):
++            backoff = retry_after_backoff(
++                getattr(self.configuration, 'retries', None),
++                getattr(self.configuration, 'client_go_retry_backoff', None),
++            )
++            r = await async_on_retry_after_error(
++                backoff, self._is_read_retryable,
++                lambda: read_request(True))
++        else:
++            r = await read_request()
+@@ -168,2 +190 @@
+-            if not 200 <= r.status <= 299:
+-                raise ApiException(http_resp=r)
++            await self._raise_for_status(r)
+@@ -171,0 +193,22 @@
++
++    @classmethod
++    def _is_read_retryable(cls, error):
++        return is_retry_after_response(error)
++
++    @staticmethod
++    def _should_retry_response(response):
++        error = ApiException(status=response.status, reason=response.reason)
++        error.headers = response.headers
++        return is_retry_after_response(error)
++
++    @staticmethod
++    async def _response_for_exception(response):
++        if isinstance(response, RESTResponse):
++            return response
++        return RESTResponse(response, await response.read())
++
++    @classmethod
++    async def _raise_for_status(cls, response):
++        if not 200 <= response.status <= 299:
++            response = await cls._response_for_exception(response)
++            raise ApiException(http_resp=response)

--- a/openapi/python-aio.sh
+++ b/openapi/python-aio.sh
@@ -65,6 +65,8 @@ if [ ${PACKAGE_NAME} == "client" ]; then
   find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.aio.client./g' {} +
   find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes.aio.client/g' {} +
   find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/getattr(client\.models/getattr(kubernetes.aio.client.models/g' {} +
+  patch "${OUTPUT_DIR}/client/rest.py" "${SCRIPT_ROOT}/python-aio-client-go-retry-rest.patch"
+  patch "${OUTPUT_DIR}/client/configuration.py" "${SCRIPT_ROOT}/python-aio-client-go-retry-configuration.patch"
 
 else
 

--- a/openapi/python-client-go-retry-configuration.patch
+++ b/openapi/python-client-go-retry-configuration.patch
@@ -1,0 +1,19 @@
+--- configuration.py
++++ configuration.py
+@@ -307,0 +308,16 @@
++        """
++        self.client_go_retries = False
++        """Enable Kubernetes client-go-compatible retry semantics.
++
++           When enabled, GET and HEAD requests are retried on responses with
++           a 429 or 5xx status code and a valid Retry-After header. The
++           retry ceiling is read from ``retries`` when set; otherwise it
++           follows the client-go default of at most 10 retries.
++        """
++        self.client_go_retry_backoff = None
++        """Backoff for Kubernetes client-go-compatible retries.
++
++           If unset, client-go-compatible GET and HEAD retries use the
++           client-go default retry ceiling with no additional client-side
++           delay beyond Retry-After. When set, ``retries`` still overrides
++           the retry ceiling if it is not None.

--- a/openapi/python-client-go-retry-rest.patch
+++ b/openapi/python-client-go-retry-rest.patch
@@ -1,0 +1,110 @@
+--- rest.py
++++ rest.py
+@@ -18,0 +19,6 @@
++from kubernetes.utils.retry import (
++    is_retry_after_response,
++    on_retry_after_error,
++    retry_after_backoff,
++)
++from urllib3.util.retry import Retry
+@@ -43,0 +50,2 @@
++        self.configuration = configuration
++
+@@ -143,0 +152,23 @@
++        client_go_retries = getattr(self.configuration, 'client_go_retries',
++                                    False)
++        request_retries = None
++        if client_go_retries:
++            request_retries = self._urllib3_retries_without_status(
++                getattr(self.configuration, 'retries', None))
++
++        def pool_request(*args, **kwargs):
++            if request_retries is not None:
++                kwargs['retries'] = request_retries
++            return self.pool_manager.request(*args, **kwargs)
++
++        def read_request(check_retry_status=False):
++            response = pool_request(
++                method, url,
++                fields=query_params,
++                preload_content=_preload_content,
++                timeout=timeout,
++                headers=headers)
++            if check_retry_status and self._should_retry_response(response):
++                self._raise_for_status(response)
++            return response
++
+@@ -153 +184 @@
+-                    r = self.pool_manager.request(
++                    r = pool_request(
+@@ -160 +191 @@
+-                    r = self.pool_manager.request(
++                    r = pool_request(
+@@ -172 +203 @@
+-                    r = self.pool_manager.request(
++                    r = pool_request(
+@@ -184 +215 @@
+-                    r = self.pool_manager.request(
++                    r = pool_request(
+@@ -213,14 +244 @@
+-        if not 200 <= r.status <= 299:
+-            if r.status == 401:
+-                raise UnauthorizedException(http_resp=r)
+-
+-            if r.status == 403:
+-                raise ForbiddenException(http_resp=r)
+-
+-            if r.status == 404:
+-                raise NotFoundException(http_resp=r)
+-
+-            if 500 <= r.status <= 599:
+-                raise ServiceException(http_resp=r)
+-
+-            raise ApiException(http_resp=r)
++        self._raise_for_status(r)
+@@ -228,0 +247,45 @@
++
++    @classmethod
++    def _is_read_retryable(cls, error):
++        return is_retry_after_response(error)
++
++    @staticmethod
++    def _should_retry_response(response):
++        error = ApiException(status=response.status, reason=response.reason)
++        error.headers = response.getheaders()
++        return is_retry_after_response(error)
++
++    @staticmethod
++    def _urllib3_retries_without_status(retries):
++        if retries is False:
++            return False
++        if retries is None:
++            retries = Retry.DEFAULT
++        elif retries is True:
++            retries = Retry.DEFAULT
++        elif isinstance(retries, int):
++            retries = Retry.from_int(retries)
++        if isinstance(retries, Retry):
++            return retries.new(
++                status=0,
++                status_forcelist=(),
++                respect_retry_after_header=False,
++            )
++        return retries
++
++    @classmethod
++    def _raise_for_status(cls, response):
++        if not 200 <= response.status <= 299:
++            if response.status == 401:
++                raise UnauthorizedException(http_resp=response)
++
++            if response.status == 403:
++                raise ForbiddenException(http_resp=response)
++
++            if response.status == 404:
++                raise NotFoundException(http_resp=response)
++
++            if 500 <= response.status <= 599:
++                raise ServiceException(http_resp=response)
++
++            raise ApiException(http_resp=response)

--- a/openapi/python-client-go-retry-rest.patch
+++ b/openapi/python-client-go-retry-rest.patch
@@ -46,6 +46,23 @@
 @@ -184 +215 @@
 -                    r = self.pool_manager.request(
 +                    r = pool_request(
+@@ -198,5 +229,11 @@
+-                r = self.pool_manager.request(method, url,
+-                                              fields=query_params,
+-                                              preload_content=_preload_content,
+-                                              timeout=timeout,
+-                                              headers=headers)
++                if _preload_content and client_go_retries:
++                    backoff = retry_after_backoff(
++                        getattr(self.configuration, 'retries', None),
++                        getattr(self.configuration, 'client_go_retry_backoff',
++                                None),
++                    )
++                    r = on_retry_after_error(
++                        backoff, self._is_read_retryable,
++                        lambda: read_request(True))
++                else:
++                    r = read_request()
 @@ -213,14 +244 @@
 -        if not 200 <= r.status <= 299:
 -            if r.status == 401:

--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -64,6 +64,8 @@ if [ "${PACKAGE_NAME}" = client ]; then
     find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.client./g' {} +
     find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes.client/g' {} +
     find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/getattr(client\.models/getattr(kubernetes.client.models/g' {} +
+    patch "${OUTPUT_DIR}/client/rest.py" "${SCRIPT_ROOT}/python-client-go-retry-rest.patch"
+    patch "${OUTPUT_DIR}/client/configuration.py" "${SCRIPT_ROOT}/python-client-go-retry-configuration.patch"
 fi
 
 echo "---Done."


### PR DESCRIPTION
## Summary
- apply Kubernetes-specific post-generation patches for sync and async Python clients
- add opt-in `client_go_retries` and `client_go_retry_backoff` configuration fields to generated clients
- wire generated GET/HEAD requests to the client-go-compatible retry helpers from kubernetes-client/python#2634
- use the public helper paths `kubernetes.utils.retry` for sync and `kubernetes.aio.utils.retry` for AIO

## Validation
- dry-ran the new patches against OpenAPI Generator v6.6.0 `python-legacy` templates
- dry-ran existing downstream Python REST patches after applying the generator retry patches
- ran `git diff --check`

Depends on kubernetes-client/python#2634.
