### PR TITLE
Migrate synchronous Python client generation to OpenAPI Generator v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,10 @@ jobs:
 
       - name: Run unit tests
         working-directory: ./openapi
-        run: python3 test_apidiscovery.py
+        run: |
+          python3 test_apidiscovery.py
+          python3 -m unittest test_postprocess_python.py
+          python3 -m unittest test_preprocess.py
 
       - name: Run integration tests
         working-directory: ./openapi

--- a/openapi/apidiscovery_definitions.json
+++ b/openapi/apidiscovery_definitions.json
@@ -1,4 +1,19 @@
 {
+  "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionKind": {
+    "type": "object",
+    "description": "GroupVersionKind unambiguously identifies a kind.",
+    "properties": {
+      "group": {
+        "type": "string"
+      },
+      "version": {
+        "type": "string"
+      },
+      "kind": {
+        "type": "string"
+      }
+    }
+  },
   "io.k8s.api.apidiscovery.v2beta1.APIGroupDiscoveryList": {
     "type": "object",
     "description": "APIGroupDiscoveryList is a resource containing a list of APIGroupDiscovery. This is one of the types able to be returned from the /api and /apis endpoint and contains an aggregated list of API resources (built-ins, Custom Resource Definitions, resources from aggregated servers) that a cluster supports.",

--- a/openapi/postprocess_python.py
+++ b/openapi/postprocess_python.py
@@ -129,20 +129,6 @@ for path, file_type in [
             "@validate_call\n",
             "@validate_call(config={'defer_build': True})\n",
         )
-        if (
-            path.name == "__init__.py"
-            and "from lazy_imports import LazyModule, as_package, load" in text
-            and "_lazy_module.__spec__ = __spec__" not in text
-        ):
-            # LazyModule replaces sys.modules without carrying importlib's
-            # package metadata, which breaks find_spec and resources.files.
-            text += (
-                '\n    _lazy_module = __import__("sys").modules[__name__]\n'
-                "    _lazy_module.__package__ = __package__\n"
-                "    _lazy_module.__loader__ = __loader__\n"
-                "    _lazy_module.__spec__ = __spec__\n"
-            )
-
     # Generated files otherwise fail git diff --check on trailing whitespace
     # and extra blank lines at EOF.
     lines = text.splitlines()

--- a/openapi/postprocess_python.py
+++ b/openapi/postprocess_python.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+from pathlib import Path
+
+
+parser = argparse.ArgumentParser(
+    description="Post-process the generated Python client."
+)
+parser.add_argument("output_directory", type=Path)
+parser.add_argument("package_name")
+args = parser.parse_args()
+
+# Swagger 2 exposes these IntOrString fields as free-form objects, which makes
+# the generated Pydantic validators reject valid scalar values. Kubernetes
+# serializes them as the contained integer or string:
+# https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go#L32-L45
+int_or_string_fields = {
+    "v1httpgetaction": ("port",),
+    "v1networkpolicyport": ("port",),
+    "v1poddisruptionbudgetspec": ("max_unavailable", "min_available"),
+    "v1rollingupdatedaemonset": ("max_surge", "max_unavailable"),
+    "v1rollingupdatedeployment": ("max_surge", "max_unavailable"),
+    "v1rollingupdatestatefulsetstrategy": ("max_unavailable",),
+    "v1serviceport": ("target_port",),
+    "v1tcpsocketaction": ("port",),
+}
+
+# kube-openapi cannot describe these JSONSchemaProps unions until it supports
+# anyOf. Preserve the Kubernetes JSON contract in generated validators/docs:
+# https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go#L75-L112
+# https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go#L348-L403
+json_schema_props_fields = {
+    "additional_items": (
+        "Optional[Dict[str, Any]]",
+        "Optional[Dict[str, Any] | StrictBool]",
+        "object",
+        "Union[Dict[str, Any], bool]",
+    ),
+    "additional_properties": (
+        "Optional[Dict[str, Any]]",
+        "Optional[Dict[str, Any] | StrictBool]",
+        "object",
+        "Union[Dict[str, Any], bool]",
+    ),
+    "default": ("Optional[Dict[str, Any]]", "Any", "object", "Any"),
+    "dependencies": (
+        "Optional[Dict[str, Dict[str, Any]]]",
+        "Optional[Dict[str, Dict[str, Any] | List[str]]]",
+        "Dict[str, object]",
+        "Dict[str, Union[Dict[str, Any], List[str]]]",
+    ),
+    "enum": (
+        "Optional[List[Dict[str, Any]]]",
+        "Optional[List[Any]]",
+        "List[object]",
+        "List[Any]",
+    ),
+    "example": ("Optional[Dict[str, Any]]", "Any", "object", "Any"),
+    "items": (
+        "Optional[Dict[str, Any]]",
+        "Optional[Dict[str, Any] | List[Dict[str, Any]]]",
+        "object",
+        "Union[Dict[str, Any], List[Dict[str, Any]]]",
+    ),
+}
+
+markdown_files = [args.output_directory / "README.md"]
+markdown_files.extend((args.output_directory / "docs").rglob("*.md"))
+python_files = (args.output_directory / args.package_name).rglob("*.py")
+
+for path, file_type in [
+    *((path, "markdown") for path in markdown_files),
+    *((path, "python") for path in python_files),
+]:
+    text = path.read_text()
+    if file_type == "markdown":
+        if path.name == "README.md":
+            text = re.sub(
+                r"\A# client(?=\r?\n|\Z)", "# kubernetes.client", text
+            )
+        text = re.sub(
+            r"(?<![\w.-])client(?=\.[A-Za-z_])",
+            "kubernetes.client",
+            text,
+        )
+        text = re.sub(
+            r"(?m)^(\s*(?:from|import)\s+)client(?=[.\s]|$)",
+            r"\1kubernetes.client",
+            text,
+        )
+        for field in int_or_string_fields.get(path.stem.lower(), ()):
+            text = text.replace(
+                f"**{field}** | **object** |",
+                f"**{field}** | **Union[int, str]** |",
+            )
+        if path.stem == "V1JSONSchemaProps":
+            for field, (_, _, old_type, new_type) in (
+                json_schema_props_fields.items()
+            ):
+                text = text.replace(
+                    f"**{field}** | **{old_type}** |",
+                    f"**{field}** | **{new_type}** |",
+                )
+    elif args.package_name == "client":
+        text = text.replace("import client.", "import kubernetes.client.")
+        text = text.replace("from client", "from kubernetes.client")
+        text = text.replace(
+            "getattr(client.models", "getattr(kubernetes.client.models"
+        )
+        # Building every API method's Pydantic schema at import time is
+        # expensive. defer_build is supported for validate_call since 2.11:
+        # https://github.com/pydantic/pydantic/commit/8e98bc0a66379e693780eb6edd611f4177c60c30
+        text = text.replace(
+            "@validate_call\n",
+            "@validate_call(config={'defer_build': True})\n",
+        )
+        if (
+            path.name == "__init__.py"
+            and "from lazy_imports import LazyModule, as_package, load" in text
+            and "_lazy_module.__spec__ = __spec__" not in text
+        ):
+            # LazyModule replaces sys.modules without carrying importlib's
+            # package metadata, which breaks find_spec and resources.files.
+            text += (
+                '\n    _lazy_module = __import__("sys").modules[__name__]\n'
+                "    _lazy_module.__package__ = __package__\n"
+                "    _lazy_module.__loader__ = __loader__\n"
+                "    _lazy_module.__spec__ = __spec__\n"
+            )
+
+    # Generated files otherwise fail git diff --check on trailing whitespace
+    # and extra blank lines at EOF.
+    lines = text.splitlines()
+    if file_type == "python":
+        int_or_string = int_or_string_fields.get(
+            path.stem.replace("_", "").lower(), ()
+        )
+        if int_or_string:
+            for index, line in enumerate(lines):
+                if line.startswith("from pydantic import "):
+                    if "StrictInt" not in line:
+                        if "StrictStr" in line:
+                            line = line.replace(
+                                ", StrictStr", ", StrictInt, StrictStr"
+                            )
+                        else:
+                            line += ", StrictInt"
+                    if "StrictStr" not in line:
+                        line += ", StrictStr"
+                    lines[index] = line
+                    break
+        for field in int_or_string:
+            lines = [
+                line.replace(
+                    f"    {field}: Optional[Dict[str, Any]]",
+                    f"    {field}: Optional[StrictInt | StrictStr]",
+                ).replace(
+                    f"    {field}: Dict[str, Any]",
+                    f"    {field}: StrictInt | StrictStr",
+                )
+                for line in lines
+            ]
+        if path.stem == "v1_json_schema_props":
+            for field, (old_type, new_type, _, _) in (
+                json_schema_props_fields.items()
+            ):
+                lines = [
+                    line.replace(
+                        f"    {field}: {old_type}",
+                        f"    {field}: {new_type}",
+                    )
+                    for line in lines
+                ]
+        if any(line.startswith("    def patch_") for line in lines):
+            lines = [
+                line.replace(
+                    "from pydantic import validate_call, ",
+                    "from pydantic import BaseModel, validate_call, ",
+                )
+                for line in lines
+            ]
+        patch_method = False
+        for index, line in enumerate(lines):
+            if line.startswith("    def "):
+                patch_method = line.startswith("    def patch_")
+            if patch_method:
+                # Swagger 2 describes PATCH bodies as objects, but RFC 6902
+                # represents a JSON Patch document as an array of operations:
+                # https://www.rfc-editor.org/rfc/rfc6902#section-3
+                # Generated request models are also valid object PATCH bodies.
+                lines[index] = line.replace(
+                    "body: Annotated[Dict[str, Any]",
+                    "body: Annotated[Union[Dict[str, Any], List[Dict[str, Any]], BaseModel]",
+                ).replace(
+                    "body: Dict[str, Any]",
+                    "body: Union[Dict[str, Any], List[Dict[str, Any]], BaseModel]",
+                )
+    while lines and not lines[-1].strip(" \t"):
+        lines.pop()
+    path.write_text(
+        "\n".join(line.rstrip(" \t") for line in lines) + "\n"
+    )

--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -143,6 +143,58 @@ def strip_tags_from_operation_id(operation, _):
             operation_id = operation_id.replace(_to_camel_case(t), '')
         operation['operationId'] = operation_id
 
+
+def fix_exec_command_parameter(operation, parent):
+    if operation.get('operationId') not in {
+        'connectCoreV1GetNamespacedPodExec',
+        'connectCoreV1PostNamespacedPodExec',
+    }:
+        return
+    for parameter in parent.get('parameters', []) + operation.get(
+        'parameters', []
+    ):
+        if parameter.get('name') == 'command':
+            # PodExecOptions.Command is []string, but the published Swagger 2
+            # document describes it as a scalar:
+            # https://github.com/kubernetes/kubernetes/blob/1a4d068e60ecd4b467a04c37c86c4882e419f24d/staging/src/k8s.io/api/core/v1/types.go#L7361-L7363
+            parameter['type'] = 'array'
+            parameter['items'] = {'type': 'string'}
+            parameter['collectionFormat'] = 'multi'
+
+
+def fix_python_portforward_ports_parameter(operation, parent):
+    if operation.get('operationId') not in {
+        'connectCoreV1GetNamespacedPodPortforward',
+        'connectCoreV1PostNamespacedPodPortforward',
+    }:
+        return
+    for parameter in parent.get('parameters', []) + operation.get(
+        'parameters', []
+    ):
+        if parameter.get('name') == 'ports':
+            # This WebSocket query is comma-separated, while the published
+            # Swagger integer makes modern Python clients reject existing
+            # values such as "80,443":
+            # https://github.com/kubernetes/kubernetes/blob/1a4d068e60ecd4b467a04c37c86c4882e419f24d/staging/src/k8s.io/api/core/v1/types.go#L7373-L7383
+            parameter['type'] = 'string'
+            parameter.pop('format', None)
+
+
+def fix_python_namespace_delete_response(operation, _):
+    if operation.get('operationId') != 'deleteCoreV1Namespace':
+        return
+    # Namespace storage normally returns the deleted Namespace, but unsafe
+    # deletion cannot recover the object and returns a Status. Swagger 2
+    # cannot describe that union, so preserve either response as an object:
+    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/pkg/registry/core/namespace/storage/storage.go#L59-L73
+    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go#L104-L127
+    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go#L194-L207
+    for status in ('200', '202'):
+        response = operation.get('responses', {}).get(status)
+        if response is not None:
+            response['schema'] = {'type': 'object'}
+
+
 def clean_crd_meta(spec):
     for k, v in spec['definitions'].items():
         if k.endswith('List'):
@@ -161,9 +213,21 @@ def clean_crd_meta(spec):
         find_rename_ref_recursive(spec, '#/definitions/io.k8s.api.autoscaling.v1.Scale_v2', '#/definitions/v1.Scale')
 
 
-def add_custom_objects_spec(spec):
+def add_custom_objects_spec(spec, client_language):
     with open(CUSTOM_OBJECTS_SPEC_PATH, 'r') as custom_objects_spec_file:
         custom_objects_spec = json.load(custom_objects_spec_file)
+    if client_language == 'python':
+        for path_item in custom_objects_spec.values():
+            patch = path_item.get('patch')
+            if patch is not None:
+                # Preserve merge patch as the default for Python custom
+                # objects; callers can still select JSON Patch explicitly:
+                # https://github.com/kubernetes-client/python/issues/866
+                patch['consumes'] = [
+                    content_type
+                    for content_type in patch.get('consumes', [])
+                    if content_type != 'application/json-patch+json'
+                ]
     for path in custom_objects_spec.keys():
         if path not in spec['paths'].keys():
             spec['paths'][path] = custom_objects_spec[path]
@@ -182,6 +246,18 @@ def add_apidiscovery_definitions(spec):
         if definition_name not in spec['definitions']:
             spec['definitions'][definition_name] = definition
     return spec
+
+
+def add_bearer_token_alias(spec, client_language):
+    if client_language != 'python':
+        return spec
+    bearer_token = spec.get('securityDefinitions', {}).get('BearerToken')
+    if bearer_token is not None:
+        # Preserve the api_key['authorization'] key accepted before v36:
+        # https://github.com/kubernetes-client/python/issues/2595
+        bearer_token['x-auth-id-alias'] = 'authorization'
+    return spec
+
 
 def add_codegen_request_body(operation, _):
     if 'parameters' in operation and len(operation['parameters']) > 0:
@@ -235,8 +311,9 @@ def expand_parameters(spec):
     del spec['parameters']
 
 def process_swagger(spec, client_language, crd_mode=False):
-    spec = add_custom_objects_spec(spec)
+    spec = add_custom_objects_spec(spec, client_language)
     spec = add_apidiscovery_definitions(spec)
+    spec = add_bearer_token_alias(spec, client_language)
 
     if crd_mode:
         drop_paths(spec)
@@ -244,6 +321,13 @@ def process_swagger(spec, client_language, crd_mode=False):
     fix_paths(spec)
 
     expand_parameters(spec)
+
+    if client_language == 'python':
+        apply_func_to_spec_operations(spec, fix_exec_command_parameter)
+        apply_func_to_spec_operations(
+            spec, fix_python_portforward_ports_parameter)
+        apply_func_to_spec_operations(
+            spec, fix_python_namespace_delete_response)
 
     apply_func_to_spec_operations(spec, strip_tags_from_operation_id)
 

--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -45,7 +45,7 @@ popd > /dev/null
 
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v7.24.0}"
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-830e9d156960bb7f51a5337f31636a7e73226474}"
 
 CLIENT_LANGUAGE=python; \
 CLEANUP_DIRS=(client/api client/models docs); \

--- a/openapi/python.sh
+++ b/openapi/python.sh
@@ -45,25 +45,16 @@ popd > /dev/null
 
 source "${SCRIPT_ROOT}/openapi-generator/client-generator.sh"
 source "${SETTING_FILE}"
-OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v6.6.0}"
+OPENAPI_GENERATOR_COMMIT="${OPENAPI_GENERATOR_COMMIT:-v7.24.0}"
 
 CLIENT_LANGUAGE=python; \
-CLEANUP_DIRS=(client/api client/apis client/models docs test); \
+CLEANUP_DIRS=(client/api client/models docs); \
 kubeclient::generator::generate_client "${OUTPUT_DIR}"
 
-echo "--- Patching generated code..."
+echo "--- Post-processing generated code..."
 
-# Post-processing of the generated Python wrapper.
-find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i 's/\bclient/kubernetes.client/g' {} +
-find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/\bclient/kubernetes.client/g' {} +
-find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes.client-python/client-python/g' {} +
-find "${OUTPUT_DIR}" -path "${OUTPUT_DIR}/base" -prune -o -type f -a -name \*.md -exec sed -i 's/kubernetes-kubernetes.client/kubernetes-client/g' {} +
-
-# fix imports
-if [ "${PACKAGE_NAME}" = client ]; then
-    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/import client\./import kubernetes.client./g' {} +
-    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/from client/from kubernetes.client/g' {} +
-    find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i 's/getattr(client\.models/getattr(kubernetes.client.models/g' {} +
-fi
+python3 "${SCRIPT_ROOT}/postprocess_python.py" \
+    "${OUTPUT_DIR}" \
+    "${PACKAGE_NAME}"
 
 echo "---Done."

--- a/openapi/python.xml
+++ b/openapi/python.xml
@@ -18,14 +18,32 @@
                         </goals>
                         <configuration>
                             <inputSpec>${generator.spec.path}</inputSpec>
-                            <generatorName>python-legacy</generatorName>
+                            <generatorName>python</generatorName>
                             <gitUserId>kubernetes-client</gitUserId>
                             <gitRepoId>python</gitRepoId>
                             <skipValidateSpec>true</skipValidateSpec>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <nameMappings>
+                                <nameMapping>$schema=schema</nameMapping>
+                                <nameMapping>continue=_continue</nameMapping>
+                                <nameMapping>except=_except</nameMapping>
+                                <nameMapping>exec=_exec</nameMapping>
+                                <nameMapping>field=field</nameMapping>
+                                <nameMapping>from=_from</nameMapping>
+                                <nameMapping>not=_not</nameMapping>
+                                <nameMapping>schema=schema</nameMapping>
+                            </nameMappings>
+                            <parameterNameMappings>
+                                <parameterNameMapping>continue=_continue</parameterNameMapping>
+                            </parameterNameMappings>
                             <configOptions>
                                 <packageName>${generator.package.name}</packageName>
                                 <packageVersion>${generator.client.version}</packageVersion>
                                 <sortParamsByRequiredFlag>true</sortParamsByRequiredFlag>
+                                <lazyImports>true</lazyImports>
+                                <useIndependentImplicitClients>true</useIndependentImplicitClients>
+                                <compatibleWithPythonLegacy>true</compatibleWithPythonLegacy>
                             </configOptions>
                             <output>${generator.output.path}</output>
                         </configuration>

--- a/openapi/test_apidiscovery.py
+++ b/openapi/test_apidiscovery.py
@@ -34,6 +34,7 @@ def test_apidiscovery_definitions_loaded():
     spec = add_apidiscovery_definitions(spec)
     
     expected_defs = [
+        'io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionKind',
         'io.k8s.api.apidiscovery.v2beta1.APIGroupDiscoveryList',
         'io.k8s.api.apidiscovery.v2beta1.APIGroupDiscovery',
         'io.k8s.api.apidiscovery.v2beta1.APIVersionDiscovery',
@@ -51,6 +52,13 @@ def test_apidiscovery_definitions_loaded():
             print(f"  ✗ FAILED: {def_name} not found")
             return False
         print(f"  ✓ {def_name}")
+
+    gvk = spec['definitions'][
+        'io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionKind'
+    ]
+    if set(gvk.get('properties', {})) != {'group', 'version', 'kind'}:
+        print("  ✗ FAILED: GroupVersionKind has incomplete properties")
+        return False
     
     print("  ✓ Test 1 PASSED\n")
     return True
@@ -71,10 +79,6 @@ def test_apidiscovery_in_processed_spec():
                 'properties': {}
             },
             'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta': {
-                'type': 'object',
-                'properties': {}
-            },
-            'io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionKind': {
                 'type': 'object',
                 'properties': {}
             }

--- a/openapi/test_postprocess_python.py
+++ b/openapi/test_postprocess_python.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class PythonPostprocessingTest(unittest.TestCase):
+    def test_rewrites_generated_package_references(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_directory = Path(temporary_directory)
+            docs_directory = output_directory / "docs"
+            package_directory = output_directory / "client"
+            docs_directory.mkdir()
+            package_directory.mkdir()
+
+            readme = output_directory / "README.md"
+            model_doc = docs_directory / "V1Pod.md"
+            service_doc = docs_directory / "V1ServicePort.md"
+            json_schema_doc = docs_directory / "V1JSONSchemaProps.md"
+            package_init = package_directory / "__init__.py"
+            module = package_directory / "api_client.py"
+            service_model = package_directory / "v1_service_port.py"
+            tcp_socket_model = package_directory / "v1_tcp_socket_action.py"
+            json_schema_model = (
+                package_directory / "v1_json_schema_props.py"
+            )
+            readme.write_text(
+                "# client\n\n"
+                "Use client.CoreV1Api.  \n"
+                "import client\n"
+                "from client.api_client import ApiClient\n"
+                "The client is configured here.\n"
+                "This is a generated client.\n"
+                "Install client-python or kubernetes-client.\n"
+                "Already qualified: kubernetes.client.CoreV1Api.\n\n"
+            )
+            model_doc.write_text("See client.V1Pod.\t\n\n")
+            service_doc.write_text(
+                "**target_port** | **object** | target | [optional]\n"
+                "**metadata** | **object** | metadata | [optional]\n"
+            )
+            json_schema_doc.write_text(
+                "**additional_items** | **object** | items | [optional]\n"
+                "**additional_properties** | **object** | props | [optional]\n"
+                "**default** | **object** | default | [optional]\n"
+                "**dependencies** | **Dict[str, object]** | deps | [optional]\n"
+                "**enum** | **List[object]** | enum | [optional]\n"
+                "**example** | **object** | example | [optional]\n"
+                "**items** | **object** | items | [optional]\n"
+                "**properties** | **Dict[str, object]** | props | [optional]\n"
+            )
+            package_init.write_text(
+                'if __import__("typing").TYPE_CHECKING:\n'
+                "    from client.api_client import ApiClient\n"
+                "else:\n"
+                "    from lazy_imports import LazyModule, as_package, load\n"
+                "    load(LazyModule(*as_package(__file__), name=__name__))\n"
+            )
+            module.write_text(
+                "from pydantic import validate_call, Field\n"
+                "import client.models  \n"
+                "from client.api_client import ApiClient\n"
+                'MODEL = getattr(client.models, "V1Pod")\n\n'
+                "class CoreV1Api:\n"
+                "    @validate_call\n"
+                "    def patch_namespaced_pod(\n"
+                "        self,\n"
+                "        body: Dict[str, Any],\n"
+                "    ): ...\n\n"
+                "    def patch_custom_object(\n"
+                "        self,\n"
+                '        body: Annotated[Dict[str, Any], Field(description="patch")],\n'
+                "    ): ...\n\n"
+                "    def create_namespaced_pod(\n"
+                "        self,\n"
+                "        body: Dict[str, Any],\n"
+                "    ): ...\n\n"
+            )
+            service_model.write_text(
+                "from pydantic import Field, StrictInt\n\n"
+                "class V1ServicePort:\n"
+                "    target_port: Optional[Dict[str, Any]] = None\n"
+                "    metadata: Optional[Dict[str, Any]] = None\n"
+            )
+            tcp_socket_model.write_text(
+                "from pydantic import Field, StrictStr\n\n"
+                "class V1TCPSocketAction:\n"
+                "    port: Dict[str, Any]\n"
+            )
+            json_schema_model.write_text(
+                "class V1JSONSchemaProps:\n"
+                "    additional_items: Optional[Dict[str, Any]] = None\n"
+                "    additional_properties: Optional[Dict[str, Any]] = None\n"
+                "    default: Optional[Dict[str, Any]] = None\n"
+                "    dependencies: Optional[Dict[str, Dict[str, Any]]] = None\n"
+                "    enum: Optional[List[Dict[str, Any]]] = None\n"
+                "    example: Optional[Dict[str, Any]] = None\n"
+                "    items: Optional[Dict[str, Any]] = None\n"
+                "    properties: Optional[Dict[str, Dict[str, Any]]] = None\n"
+            )
+
+            for _ in range(2):
+                subprocess.run(
+                    [
+                        sys.executable,
+                        str(Path(__file__).with_name("postprocess_python.py")),
+                        str(output_directory),
+                        "client",
+                    ],
+                    check=True,
+                )
+
+            self.assertEqual(
+                "# kubernetes.client\n\n"
+                "Use kubernetes.client.CoreV1Api.\n"
+                "import kubernetes.client\n"
+                "from kubernetes.client.api_client import ApiClient\n"
+                "The client is configured here.\n"
+                "This is a generated client.\n"
+                "Install client-python or kubernetes-client.\n"
+                "Already qualified: kubernetes.client.CoreV1Api.\n",
+                readme.read_text(),
+            )
+            self.assertEqual(
+                "See kubernetes.client.V1Pod.\n",
+                model_doc.read_text(),
+            )
+            self.assertEqual(
+                "**target_port** | **Union[int, str]** | target | [optional]\n"
+                "**metadata** | **object** | metadata | [optional]\n",
+                service_doc.read_text(),
+            )
+            self.assertEqual(
+                "**additional_items** | **Union[Dict[str, Any], bool]** | items | [optional]\n"
+                "**additional_properties** | **Union[Dict[str, Any], bool]** | props | [optional]\n"
+                "**default** | **Any** | default | [optional]\n"
+                "**dependencies** | **Dict[str, Union[Dict[str, Any], List[str]]]** | deps | [optional]\n"
+                "**enum** | **List[Any]** | enum | [optional]\n"
+                "**example** | **Any** | example | [optional]\n"
+                "**items** | **Union[Dict[str, Any], List[Dict[str, Any]]]** | items | [optional]\n"
+                "**properties** | **Dict[str, object]** | props | [optional]\n",
+                json_schema_doc.read_text(),
+            )
+            self.assertEqual(
+                'if __import__("typing").TYPE_CHECKING:\n'
+                "    from kubernetes.client.api_client import ApiClient\n"
+                "else:\n"
+                "    from lazy_imports import LazyModule, as_package, load\n"
+                "    load(LazyModule(*as_package(__file__), name=__name__))\n"
+                '\n    _lazy_module = __import__("sys").modules[__name__]\n'
+                "    _lazy_module.__package__ = __package__\n"
+                "    _lazy_module.__loader__ = __loader__\n"
+                "    _lazy_module.__spec__ = __spec__\n",
+                package_init.read_text(),
+            )
+            self.assertEqual(
+                "from pydantic import BaseModel, validate_call, Field\n"
+                "import kubernetes.client.models\n"
+                "from kubernetes.client.api_client import ApiClient\n"
+                'MODEL = getattr(kubernetes.client.models, "V1Pod")\n\n'
+                "class CoreV1Api:\n"
+                "    @validate_call(config={'defer_build': True})\n"
+                "    def patch_namespaced_pod(\n"
+                "        self,\n"
+                "        body: Union[Dict[str, Any], List[Dict[str, Any]], BaseModel],\n"
+                "    ): ...\n\n"
+                "    def patch_custom_object(\n"
+                "        self,\n"
+                '        body: Annotated[Union[Dict[str, Any], List[Dict[str, Any]], BaseModel], Field(description="patch")],\n'
+                "    ): ...\n\n"
+                "    def create_namespaced_pod(\n"
+                "        self,\n"
+                "        body: Dict[str, Any],\n"
+                "    ): ...\n",
+                module.read_text(),
+            )
+            self.assertEqual(
+                "from pydantic import Field, StrictInt, StrictStr\n\n"
+                "class V1ServicePort:\n"
+                "    target_port: Optional[StrictInt | StrictStr] = None\n"
+                "    metadata: Optional[Dict[str, Any]] = None\n",
+                service_model.read_text(),
+            )
+            self.assertEqual(
+                "from pydantic import Field, StrictInt, StrictStr\n\n"
+                "class V1TCPSocketAction:\n"
+                "    port: StrictInt | StrictStr\n",
+                tcp_socket_model.read_text(),
+            )
+            self.assertEqual(
+                "class V1JSONSchemaProps:\n"
+                "    additional_items: Optional[Dict[str, Any] | StrictBool] = None\n"
+                "    additional_properties: Optional[Dict[str, Any] | StrictBool] = None\n"
+                "    default: Any = None\n"
+                "    dependencies: Optional[Dict[str, Dict[str, Any] | List[str]]] = None\n"
+                "    enum: Optional[List[Any]] = None\n"
+                "    example: Any = None\n"
+                "    items: Optional[Dict[str, Any] | List[Dict[str, Any]]] = None\n"
+                "    properties: Optional[Dict[str, Dict[str, Any]]] = None\n",
+                json_schema_model.read_text(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openapi/test_postprocess_python.py
+++ b/openapi/test_postprocess_python.py
@@ -66,11 +66,21 @@ class PythonPostprocessingTest(unittest.TestCase):
                 "**properties** | **Dict[str, object]** | props | [optional]\n"
             )
             package_init.write_text(
-                'if __import__("typing").TYPE_CHECKING:\n'
+                '__all__ = ["ApiClient"]\n\n'
+                "import typing as _typing\n\n"
+                "if _typing.TYPE_CHECKING:\n"
                 "    from client.api_client import ApiClient\n"
                 "else:\n"
-                "    from lazy_imports import LazyModule, as_package, load\n"
-                "    load(LazyModule(*as_package(__file__), name=__name__))\n"
+                "    from importlib import import_module\n\n"
+                '    _exports = {"ApiClient": ".api_client"}\n\n'
+                "    def __getattr__(name: str) -> object:\n"
+                "        if (module_name := _exports.get(name)) is None:\n"
+                '            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")\n'
+                "        value = getattr(import_module(module_name, __name__), name)\n"
+                "        globals()[name] = value\n"
+                "        return value\n\n"
+                "    def __dir__() -> list[str]:\n"
+                "        return sorted(globals().keys() | _exports.keys())\n"
             )
             module.write_text(
                 "from pydantic import validate_call, Field\n"
@@ -158,15 +168,21 @@ class PythonPostprocessingTest(unittest.TestCase):
                 json_schema_doc.read_text(),
             )
             self.assertEqual(
-                'if __import__("typing").TYPE_CHECKING:\n'
+                '__all__ = ["ApiClient"]\n\n'
+                "import typing as _typing\n\n"
+                "if _typing.TYPE_CHECKING:\n"
                 "    from kubernetes.client.api_client import ApiClient\n"
                 "else:\n"
-                "    from lazy_imports import LazyModule, as_package, load\n"
-                "    load(LazyModule(*as_package(__file__), name=__name__))\n"
-                '\n    _lazy_module = __import__("sys").modules[__name__]\n'
-                "    _lazy_module.__package__ = __package__\n"
-                "    _lazy_module.__loader__ = __loader__\n"
-                "    _lazy_module.__spec__ = __spec__\n",
+                "    from importlib import import_module\n\n"
+                '    _exports = {"ApiClient": ".api_client"}\n\n'
+                "    def __getattr__(name: str) -> object:\n"
+                "        if (module_name := _exports.get(name)) is None:\n"
+                '            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")\n'
+                "        value = getattr(import_module(module_name, __name__), name)\n"
+                "        globals()[name] = value\n"
+                "        return value\n\n"
+                "    def __dir__() -> list[str]:\n"
+                "        return sorted(globals().keys() | _exports.keys())\n",
                 package_init.read_text(),
             )
             self.assertEqual(

--- a/openapi/test_preprocess.py
+++ b/openapi/test_preprocess.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import unittest
+
+from preprocess_spec import process_swagger
+
+
+class PythonPreprocessingTest(unittest.TestCase):
+    def test_preserves_python_client_contracts(self):
+        exec_path = '/api/v1/namespaces/{namespace}/pods/{name}/exec'
+        portforward_path = (
+            '/api/v1/namespaces/{namespace}/pods/{name}/portforward'
+        )
+        namespace_path = '/api/v1/namespaces/{name}'
+        spec = {
+            'swagger': '2.0',
+            'info': {'version': 'v1.0.0'},
+            'paths': {
+                exec_path: {
+                    'parameters': [{
+                        'description': 'argv array',
+                        'in': 'query',
+                        'name': 'command',
+                        'type': 'string',
+                    }],
+                    'get': {
+                        'operationId': 'connectCoreV1GetNamespacedPodExec',
+                        'responses': {'200': {'description': 'OK'}},
+                        'tags': ['core_v1'],
+                    },
+                },
+                portforward_path: {
+                    'parameters': [{
+                        'description': 'comma-separated ports',
+                        'format': 'int32',
+                        'in': 'query',
+                        'name': 'ports',
+                        'type': 'integer',
+                    }],
+                    'get': {
+                        'operationId': (
+                            'connectCoreV1GetNamespacedPodPortforward'
+                        ),
+                        'responses': {'200': {'description': 'OK'}},
+                        'tags': ['core_v1'],
+                    },
+                },
+                namespace_path: {
+                    'delete': {
+                        'operationId': 'deleteCoreV1Namespace',
+                        'responses': {
+                            status: {
+                                'description': 'OK',
+                                'schema': {
+                                    '$ref': (
+                                        '#/definitions/io.k8s.apimachinery.'
+                                        'pkg.apis.meta.v1.Status'
+                                    ),
+                                },
+                            }
+                            for status in ('200', '202')
+                        },
+                        'tags': ['core_v1'],
+                    },
+                },
+            },
+            'definitions': {
+                'io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionKind': {
+                    'type': 'object',
+                    'properties': {},
+                },
+                'io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta': {
+                    'type': 'object',
+                    'properties': {},
+                },
+                'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta': {
+                    'type': 'object',
+                    'properties': {},
+                },
+                'io.k8s.apimachinery.pkg.apis.meta.v1.Status': {
+                    'type': 'object',
+                    'properties': {},
+                },
+                'io.k8s.api.core.v1.Namespace': {
+                    'type': 'object',
+                    'properties': {},
+                },
+            },
+            'securityDefinitions': {
+                'BearerToken': {
+                    'in': 'header',
+                    'name': 'authorization',
+                    'type': 'apiKey',
+                },
+            },
+        }
+
+        processed = process_swagger(copy.deepcopy(spec), 'python')
+        non_python = process_swagger(copy.deepcopy(spec), 'java')
+
+        command = processed['paths'][exec_path]['parameters'][0]
+        self.assertEqual('array', command['type'])
+        self.assertEqual({'type': 'string'}, command['items'])
+        self.assertEqual('multi', command['collectionFormat'])
+        ports = processed['paths'][portforward_path]['parameters'][0]
+        self.assertEqual('string', ports['type'])
+        self.assertNotIn('format', ports)
+        self.assertEqual(
+            'authorization',
+            processed['securityDefinitions']['BearerToken'][
+                'x-auth-id-alias'
+            ],
+        )
+        self.assertEqual(
+            ['application/merge-patch+json'],
+            processed['paths'][
+                '/apis/{group}/{version}/{plural}/{name}'
+            ]['patch']['consumes'],
+        )
+        self.assertNotIn(
+            'x-auth-id-alias',
+            non_python['securityDefinitions']['BearerToken'],
+        )
+        self.assertEqual(
+            'string',
+            non_python['paths'][exec_path]['parameters'][0]['type'],
+        )
+        self.assertEqual(
+            'integer',
+            non_python['paths'][portforward_path]['parameters'][0]['type'],
+        )
+        for status in ('200', '202'):
+            self.assertEqual(
+                {'type': 'object'},
+                processed['paths'][namespace_path]['delete'][
+                    'responses'
+                ][status]['schema'],
+            )
+            self.assertEqual(
+                {'$ref': '#/definitions/v1.Status'},
+                non_python['paths'][namespace_path]['delete'][
+                    'responses'
+                ][status]['schema'],
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
OpenAPI Generator v7 removed python-legacy, the backend used by the synchronous Kubernetes Python client. https://github.com/OpenAPITools/openapi-generator/pull/24402 introduces standard-library lazy imports, removing the third-party lazy-imports dependency without eagerly importing the generated API and models.

Generate the synchronous client from merged source commit 830e9d156960bb7f51a5337f31636a7e73226474. Centralize the Python schema, discovery, authentication, PATCH, and postprocessing corrections needed by https://github.com/kubernetes-client/python/pull/2652 and the independently proposed asyncio migration in https://github.com/kubernetes-client/gen/pull/306.

The pinned generator identifies itself as 7.25.0-SNAPSHOT; 7.25.0 has not been released.