### PR TITLE
Align Python resource deletion responses

### DIFF
--- a/openapi/preprocess_spec.py
+++ b/openapi/preprocess_spec.py
@@ -180,22 +180,7 @@ def fix_python_portforward_ports_parameter(operation, parent):
             parameter.pop('format', None)
 
 
-def fix_python_namespace_delete_response(operation, _):
-    if operation.get('operationId') != 'deleteCoreV1Namespace':
-        return
-    # Namespace storage normally returns the deleted Namespace, but unsafe
-    # deletion cannot recover the object and returns a Status. Swagger 2
-    # cannot describe that union, so preserve either response as an object:
-    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/pkg/registry/core/namespace/storage/storage.go#L59-L73
-    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go#L104-L127
-    # https://github.com/kubernetes/kubernetes/blob/8ba6370120c1371ab70428be16341c3cf6ba8584/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go#L194-L207
-    for status in ('200', '202'):
-        response = operation.get('responses', {}).get(status)
-        if response is not None:
-            response['schema'] = {'type': 'object'}
-
-
-def fix_python_aio_delete_response(operation, _):
+def fix_python_delete_response(operation, _):
     if operation.get('x-kubernetes-action') != 'delete':
         return
     # Resource deletion can return the deleted object or Status, but Swagger 2
@@ -345,12 +330,7 @@ def process_swagger(spec, client_language, crd_mode=False):
         apply_func_to_spec_operations(spec, fix_exec_command_parameter)
         apply_func_to_spec_operations(
             spec, fix_python_portforward_ports_parameter)
-        apply_func_to_spec_operations(
-            spec,
-            fix_python_aio_delete_response
-            if client_language == 'python-aio'
-            else fix_python_namespace_delete_response,
-        )
+        apply_func_to_spec_operations(spec, fix_python_delete_response)
 
     apply_func_to_spec_operations(spec, strip_tags_from_operation_id)
 

--- a/openapi/test_preprocess.py
+++ b/openapi/test_preprocess.py
@@ -225,7 +225,7 @@ class PythonPreprocessingTest(unittest.TestCase):
                 )
             with self.subTest(path=job_path, status=status):
                 self.assertEqual(
-                    {'$ref': '#/definitions/v1.Status'},
+                    {'type': 'object'},
                     processed['paths'][job_path]['delete'][
                         'responses'
                     ][status]['schema'],
@@ -236,6 +236,16 @@ class PythonPreprocessingTest(unittest.TestCase):
                         'responses'
                     ][status]['schema'],
                 )
+            for path in (namespace_path, job_path):
+                with self.subTest(
+                    language='python-asyncio', path=path, status=status
+                ):
+                    self.assertEqual(
+                        {'$ref': '#/definitions/v1.Status'},
+                        external_async_processed['paths'][path]['delete'][
+                            'responses'
+                        ][status]['schema'],
+                    )
             for path in (namespace_path, job_path):
                 with self.subTest(language='java', path=path, status=status):
                     self.assertEqual(


### PR DESCRIPTION
Kubernetes can return either a deleted resource or a Status from an individual deletion, but its Swagger 2 response schema names only Status. Apply the existing guarded schema correction to both Python generators so synchronous and asyncio clients preserve the complete response as a dictionary. Collection deletions and already resource-typed responses remain unchanged.

This intentionally changes 58 synchronous individual-deletion methods and their HTTP-info variants from V1Status to dictionaries relative to released v36. Callers using result.status should migrate to result.get("status").

Downstream: https://github.com/kubernetes-client/python/pull/2664
Maintainer discussion: https://github.com/kubernetes-client/gen/pull/306#discussion_r3686963670